### PR TITLE
Sano/tp/store: Refactored code to pull data from redux store

### DIFF
--- a/frontend/src/actions/plannerActions.js
+++ b/frontend/src/actions/plannerActions.js
@@ -10,6 +10,11 @@ export const plannerActions = (action, payload) => {
         type: "SET_YEARS",
         payload: payload,
       };
+    case "SET_SORTED_UNPLANNED":
+      return {
+	type: action,
+	payload: payload,
+      }
     default:
       return;
   }

--- a/frontend/src/actions/plannerActions.js
+++ b/frontend/src/actions/plannerActions.js
@@ -15,11 +15,6 @@ export const plannerActions = (action, payload) => {
         type: action,
         payload: payload,
       };
-    case "UPDATE_PLANNED_COURSES":
-      return {
-        type: action,
-        payload: payload,
-      };
     default:
       return;
   }

--- a/frontend/src/actions/plannerActions.js
+++ b/frontend/src/actions/plannerActions.js
@@ -15,6 +15,11 @@ export const plannerActions = (action, payload) => {
         type: action,
         payload: payload,
       };
+    case "UPDATE_PLANNED_COURSES":
+      return {
+        type: action,
+        payload: payload,
+      };
     default:
       return;
   }

--- a/frontend/src/actions/plannerActions.js
+++ b/frontend/src/actions/plannerActions.js
@@ -1,0 +1,32 @@
+export const plannerActions = (action, payload) => {
+  switch (action) {
+    //     case "ADD_UNPLANNED":
+    //       return {
+    //         type: "ADD_UNPLANNED",
+    //         payload: payload,
+    //       };
+    case "DELETE":
+      return {
+        type: "DELETE",
+        payload: payload,
+      };
+    case "SET_COURSES":
+      return {
+        type: "SET_COURSES",
+        payload: payload,
+      };
+    case "SET_CORE_COURSES":
+      console.log("SETTING CORE", payload);
+      return {
+        type: "SET_CORE_COURSES",
+        payload: payload,
+      };
+    case "SET_YEARS":
+      return {
+        type: "SET_YEARS",
+        payload: payload,
+      };
+    default:
+      return null;
+  }
+};

--- a/frontend/src/actions/plannerActions.js
+++ b/frontend/src/actions/plannerActions.js
@@ -10,11 +10,11 @@ export const plannerActions = (action, payload) => {
         type: "SET_YEARS",
         payload: payload,
       };
-    case "SET_SORTED_UNPLANNED":
+    case "SET_UNPLANNED":
       return {
-	type: action,
-	payload: payload,
-      }
+        type: action,
+        payload: payload,
+      };
     default:
       return;
   }

--- a/frontend/src/pages/TermPlanner/DragDropLogic.js
+++ b/frontend/src/pages/TermPlanner/DragDropLogic.js
@@ -2,7 +2,8 @@ import { plannerActions } from "../../actions/plannerActions";
 import { useSelector, useDispatch } from "react-redux";
 
 export const handleOnDragEnd = (result, dragEndProps) => {
-  const { setIsDragging, dispatch, years, startYear } = dragEndProps;
+  const { setIsDragging, dispatch, years, startYear, plannedCourses, courses } =
+    dragEndProps;
 
   setIsDragging(false);
 
@@ -21,6 +22,15 @@ export const handleOnDragEnd = (result, dragEndProps) => {
   const destTerm = destination.droppableId.match(/t[1-3]/)[0];
   const destRow = destYear - startYear;
   const destBox = years[destRow][destTerm];
+
+  checkPrereq(
+    draggableId,
+    destination,
+    plannedCourses,
+    courses,
+    dispatch,
+    draggableId
+  );
 
   // === move unplanned course to term ===
   if (source.droppableId.match(/[0-9]{4}/) === null) {
@@ -42,6 +52,7 @@ export const handleOnDragEnd = (result, dragEndProps) => {
     destCoursesCpy.splice(destination.index, 0, draggableId);
     newYears[destRow][destTerm] = destCoursesCpy;
     dispatch(plannerActions("SET_YEARS", newYears));
+
     return;
   }
 
@@ -83,4 +94,37 @@ export const handleOnDragStart = (
   const terms = courses.get(course)["termsOffered"];
   setTermsOffered(terms);
   setIsDragging(true);
+};
+
+const checkPrereq = (
+  course,
+  destination,
+  plannedCourses,
+  courses,
+  dispatch,
+  draggableId
+) => {
+  const prereqs = courses.get(course).prereqs;
+  let warning = false;
+
+  prereqs.every((prereq) => {
+    // prereq not present in planned terms
+    if (plannedCourses.get(prereq) == null) {
+      warning = true;
+      return false;
+    }
+    // course placed before (or during) prereq is complete
+    if (destination.droppableId <= plannedCourses.get(prereq)["term"]) {
+      warning = true;
+      return false;
+    }
+  });
+
+  dispatch(
+    plannerActions("UPDATE_PLANNED_COURSES", {
+      course: draggableId,
+      term: destination.droppableId,
+      warning: warning,
+    })
+  );
 };

--- a/frontend/src/pages/TermPlanner/DragDropLogic.js
+++ b/frontend/src/pages/TermPlanner/DragDropLogic.js
@@ -2,8 +2,7 @@ import { plannerActions } from "../../actions/plannerActions";
 import { useSelector, useDispatch } from "react-redux";
 
 export const handleOnDragEnd = (result, dragEndProps) => {
-  const { setIsDragging, dispatch, sortedUnplanned, years, startYear } =
-    dragEndProps;
+  const { setIsDragging, dispatch, years, startYear } = dragEndProps;
 
   setIsDragging(false);
 
@@ -23,17 +22,20 @@ export const handleOnDragEnd = (result, dragEndProps) => {
   const destRow = destYear - startYear;
   const destBox = years[destRow][destTerm];
 
-  // === move sortedUnplanned course to term ===
+  // === move unplanned course to term ===
   if (source.droppableId.match(/[0-9]{4}/) === null) {
-    // updated sortedUnplanned list
-    const type = source.droppableId;
-    const code = sortedUnplanned[type][source.index];
-    const sortedUnplannedCpy = Object.assign({}, sortedUnplanned);
-    sortedUnplannedCpy[type] = sortedUnplannedCpy[type].filter(
-      (course) => course !== code
-    );
-    // setSortedUnplanned(sortedUnplannedCpy);
-    dispatch(plannerActions("SET_SORTED_UNPLANNED", sortedUnplannedCpy));
+    //     // updated sortedUnplanned list
+    //     const type = source.droppableId;
+    //     const code = sortedUnplanned[type][source.index];
+    //     const sortedUnplannedCpy = Object.assign({}, sortedUnplanned);
+    //     sortedUnplannedCpy[type] = sortedUnplannedCpy[type].filter(
+    //       (course) => course !== code
+    //     );
+    //     console.log(draggableId);
+
+    //     // setSortedUnplanned(sortedUnplannedCpy);
+    //     dispatch(plannerActions("SET_SORTED_UNPLANNED", sortedUnplannedCpy));
+    dispatch(plannerActions("SET_UNPLANNED", draggableId));
 
     // update destination term box
     const destCoursesCpy = Array.from(years[destRow][destTerm]);

--- a/frontend/src/pages/TermPlanner/DragDropLogic.js
+++ b/frontend/src/pages/TermPlanner/DragDropLogic.js
@@ -2,8 +2,7 @@ import { plannerActions } from "../../actions/plannerActions";
 import { useSelector, useDispatch } from "react-redux";
 
 export const handleOnDragEnd = (result, dragEndProps) => {
-  const { setIsDragging, dispatch, years, startYear, plannedCourses, courses } =
-    dragEndProps;
+  const { setIsDragging, dispatch, years, startYear } = dragEndProps;
 
   setIsDragging(false);
 
@@ -22,15 +21,6 @@ export const handleOnDragEnd = (result, dragEndProps) => {
   const destTerm = destination.droppableId.match(/t[1-3]/)[0];
   const destRow = destYear - startYear;
   const destBox = years[destRow][destTerm];
-
-  checkPrereq(
-    draggableId,
-    destination,
-    plannedCourses,
-    courses,
-    dispatch,
-    draggableId
-  );
 
   // === move unplanned course to term ===
   if (source.droppableId.match(/[0-9]{4}/) === null) {
@@ -52,7 +42,6 @@ export const handleOnDragEnd = (result, dragEndProps) => {
     destCoursesCpy.splice(destination.index, 0, draggableId);
     newYears[destRow][destTerm] = destCoursesCpy;
     dispatch(plannerActions("SET_YEARS", newYears));
-
     return;
   }
 
@@ -94,37 +83,4 @@ export const handleOnDragStart = (
   const terms = courses.get(course)["termsOffered"];
   setTermsOffered(terms);
   setIsDragging(true);
-};
-
-const checkPrereq = (
-  course,
-  destination,
-  plannedCourses,
-  courses,
-  dispatch,
-  draggableId
-) => {
-  const prereqs = courses.get(course).prereqs;
-  let warning = false;
-
-  prereqs.every((prereq) => {
-    // prereq not present in planned terms
-    if (plannedCourses.get(prereq) == null) {
-      warning = true;
-      return false;
-    }
-    // course placed before (or during) prereq is complete
-    if (destination.droppableId <= plannedCourses.get(prereq)["term"]) {
-      warning = true;
-      return false;
-    }
-  });
-
-  dispatch(
-    plannerActions("UPDATE_PLANNED_COURSES", {
-      course: draggableId,
-      term: destination.droppableId,
-      warning: warning,
-    })
-  );
 };

--- a/frontend/src/pages/TermPlanner/DragDropLogic.js
+++ b/frontend/src/pages/TermPlanner/DragDropLogic.js
@@ -1,0 +1,84 @@
+import { plannerActions } from "../../actions/plannerActions";
+import { useSelector, useDispatch } from "react-redux";
+
+export const handleOnDragEnd = (result, dragEndProps) => {
+  const { setIsDragging, dispatch, sortedUnplanned, years, startYear } =
+    dragEndProps;
+
+  setIsDragging(false);
+
+  const { destination, source, draggableId } = result;
+  let newYears = [...years];
+
+  if (!destination) return; // drag outside container
+  if (
+    destination.droppableId === source.droppableId &&
+    destination.index === source.index
+  )
+    // drag to same place
+    return;
+
+  const destYear = destination.droppableId.match(/[0-9]{4}/)[0];
+  const destTerm = destination.droppableId.match(/t[1-3]/)[0];
+  const destRow = destYear - startYear;
+  const destBox = years[destRow][destTerm];
+
+  // === move sortedUnplanned course to term ===
+  if (source.droppableId.match(/[0-9]{4}/) === null) {
+    // updated sortedUnplanned list
+    const type = source.droppableId;
+    const code = sortedUnplanned[type][source.index];
+    const sortedUnplannedCpy = Object.assign({}, sortedUnplanned);
+    sortedUnplannedCpy[type] = sortedUnplannedCpy[type].filter(
+      (course) => course !== code
+    );
+    // setSortedUnplanned(sortedUnplannedCpy);
+    dispatch(plannerActions("SET_SORTED_UNPLANNED", sortedUnplannedCpy));
+
+    // update destination term box
+    const destCoursesCpy = Array.from(years[destRow][destTerm]);
+    destCoursesCpy.splice(destination.index, 0, draggableId);
+    newYears[destRow][destTerm] = destCoursesCpy;
+    dispatch(plannerActions("SET_YEARS", newYears));
+    return;
+  }
+
+  const srcYear = source.droppableId.match(/[0-9]{4}/)[0];
+  const srcTerm = source.droppableId.match(/t[1-3]/)[0];
+  const srcRow = srcYear - startYear;
+  const srcBox = years[srcRow][srcTerm];
+
+  // === move within one term ===
+  if (srcBox === destBox) {
+    const alteredBox = Array.from(srcBox);
+    alteredBox.splice(source.index, 1);
+    alteredBox.splice(destination.index, 0, draggableId);
+    newYears[srcRow][srcTerm] = alteredBox;
+    dispatch(plannerActions("SET_YEARS", newYears));
+    return;
+  }
+
+  // === move from one term to another ===
+  const srcCoursesCpy = Array.from(years[srcRow][srcTerm]);
+  srcCoursesCpy.splice(source.index, 1);
+
+  const destCoursesCpy = Array.from(years[destRow][destTerm]);
+  destCoursesCpy.splice(destination.index, 0, draggableId);
+
+  newYears[srcRow][srcTerm] = srcCoursesCpy;
+  newYears[destRow][destTerm] = destCoursesCpy;
+
+  dispatch(plannerActions("SET_YEARS", newYears));
+};
+
+export const handleOnDragStart = (
+  courseItem,
+  courses,
+  setTermsOffered,
+  setIsDragging
+) => {
+  const course = courseItem.draggableId;
+  const terms = courses.get(course)["termsOffered"];
+  setTermsOffered(terms);
+  setIsDragging(true);
+};

--- a/frontend/src/pages/TermPlanner/DraggableCourse.js
+++ b/frontend/src/pages/TermPlanner/DraggableCourse.js
@@ -2,9 +2,8 @@ import React from "react";
 import { Typography } from "antd";
 import { Draggable } from "react-beautiful-dnd";
 import { useSelector } from "react-redux";
-import { IoWarningOutline } from "react-icons/io5";
 
-function DraggableCourse({ code, index, warning }) {
+function DraggableCourse({ code, index }) {
   //   let code = course.match(/([A-Z]{4}[0-9]{4}):/)[1];
   const { Text } = Typography;
   const { courses } = useSelector((state) => {
@@ -16,21 +15,18 @@ function DraggableCourse({ code, index, warning }) {
     <Draggable draggableId={code} index={index}>
       {(provided) => (
         <li
+          className="course"
           {...provided.draggableProps}
           {...provided.dragHandleProps}
           ref={provided.innerRef}
           style={{
             ...provided.draggableProps.style,
           }}
-          className={`course ${warning && "warning"}`}
         >
-          {warning && <IoWarningOutline size="2.5em" color="#DC9930" />}
-          <div>
-            <Text strong className="text">
-              {code}
-            </Text>
-            <Text className="text">: {courseName} </Text>
-          </div>
+          <Text strong className="text">
+            {code}
+          </Text>
+          <Text className="text">: {courseName} </Text>
         </li>
       )}
     </Draggable>

--- a/frontend/src/pages/TermPlanner/DraggableCourse.js
+++ b/frontend/src/pages/TermPlanner/DraggableCourse.js
@@ -9,7 +9,7 @@ function DraggableCourse({ code, index }) {
   const { courses } = useSelector((state) => {
     return state.planner;
   });
-  const courseName = courses[code]["title"];
+  const courseName = courses.get(code)["title"];
 
   return (
     <Draggable draggableId={code} index={index}>

--- a/frontend/src/pages/TermPlanner/DraggableCourse.js
+++ b/frontend/src/pages/TermPlanner/DraggableCourse.js
@@ -2,8 +2,9 @@ import React from "react";
 import { Typography } from "antd";
 import { Draggable } from "react-beautiful-dnd";
 import { useSelector } from "react-redux";
+import { IoWarningOutline } from "react-icons/io5";
 
-function DraggableCourse({ code, index }) {
+function DraggableCourse({ code, index, warning }) {
   //   let code = course.match(/([A-Z]{4}[0-9]{4}):/)[1];
   const { Text } = Typography;
   const { courses } = useSelector((state) => {
@@ -15,18 +16,21 @@ function DraggableCourse({ code, index }) {
     <Draggable draggableId={code} index={index}>
       {(provided) => (
         <li
-          className="course"
           {...provided.draggableProps}
           {...provided.dragHandleProps}
           ref={provided.innerRef}
           style={{
             ...provided.draggableProps.style,
           }}
+          className={`course ${warning && "warning"}`}
         >
-          <Text strong className="text">
-            {code}
-          </Text>
-          <Text className="text">: {courseName} </Text>
+          {warning && <IoWarningOutline size="2.5em" color="#DC9930" />}
+          <div>
+            <Text strong className="text">
+              {code}
+            </Text>
+            <Text className="text">: {courseName} </Text>
+          </div>
         </li>
       )}
     </Draggable>

--- a/frontend/src/pages/TermPlanner/DraggableCourse.js
+++ b/frontend/src/pages/TermPlanner/DraggableCourse.js
@@ -1,11 +1,15 @@
 import React from "react";
 import { Typography } from "antd";
 import { Draggable } from "react-beautiful-dnd";
+import { useSelector } from "react-redux";
 
-function DraggableCourse({ code, index, courseNames }) {
+function DraggableCourse({ code, index }) {
   //   let code = course.match(/([A-Z]{4}[0-9]{4}):/)[1];
   const { Text } = Typography;
-  const courseName = courseNames[code]["title"];
+  const { courses } = useSelector((state) => {
+    return state.planner;
+  });
+  const courseName = courses[code]["title"];
 
   return (
     <Draggable draggableId={code} index={index}>

--- a/frontend/src/pages/TermPlanner/OptionsDrawer.js
+++ b/frontend/src/pages/TermPlanner/OptionsDrawer.js
@@ -4,25 +4,18 @@ import { Typography, Drawer, Collapse, Alert } from "antd";
 import { Droppable } from "react-beautiful-dnd";
 import DraggableCourse from "./DraggableCourse";
 import { CloseOutlined } from "@ant-design/icons";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 
 const OptionsDrawer = ({ visible, setVisible }) => {
   const { Title } = Typography;
   const { Panel } = Collapse;
 
   const theme = useSelector((state) => state.theme);
-  const { courses, unplanned, sortedUnplanned } = useSelector((state) => {
+  const { courses, unplanned } = useSelector((state) => {
     return state.planner;
   });
 
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    // get unplanned array and store the sorted version
-    dispatch(
-      plannerActions("SET_SORTED_UNPLANNED", sortUnplanned(unplanned, courses))
-    );
-  }, []);
+  const sortedUnplanned = sortUnplanned(unplanned, courses);
 
   return (
     <Drawer
@@ -45,8 +38,8 @@ const OptionsDrawer = ({ visible, setVisible }) => {
       </Title>
       {Object.keys(sortedUnplanned).length === 0 ? (
         <Alert
-          message="Oops!" // might need to change this
-          description="It looks like you haven't added any courses to your term planner. Please do so in the course selector."
+          message="Oh!"
+          description="It looks like you don't have any more courses to add to your term planner. "
           type="warning"
           showIcon
           className="alert"

--- a/frontend/src/pages/TermPlanner/OptionsDrawer.js
+++ b/frontend/src/pages/TermPlanner/OptionsDrawer.js
@@ -76,7 +76,7 @@ const createUnplannedTypes = (unplanned, courses) => {
   if (unplanned == null) return {};
   let courseTypes = {};
   unplanned.forEach((code) => {
-    const type = courses[code]["type"];
+    const type = courses.get(code)["type"];
     if (!courseTypes.hasOwnProperty(type)) {
       courseTypes[type] = [code];
     } else {

--- a/frontend/src/pages/TermPlanner/OptionsDrawer.js
+++ b/frontend/src/pages/TermPlanner/OptionsDrawer.js
@@ -6,11 +6,17 @@ import DraggableCourse from "./DraggableCourse";
 import { CloseOutlined } from "@ant-design/icons";
 import { useSelector } from "react-redux";
 
-const OptionsDrawer = ({ visible, setVisible, unplanned, data }) => {
+const OptionsDrawer = ({ visible, setVisible }) => {
   const { Title } = Typography;
   const { Panel } = Collapse;
 
   const theme = useSelector((state) => state.theme);
+  const { courses, unplanned } = useSelector((state) => {
+    return state.planner;
+  });
+
+  const unplannedByType = createUnplannedTypes(unplanned, courses);
+
   return (
     <Drawer
       placement="left"
@@ -30,7 +36,7 @@ const OptionsDrawer = ({ visible, setVisible, unplanned, data }) => {
       <Title level={2} class="text">
         Unplanned Courses
       </Title>
-      {Object.keys(unplanned).length === 0 ? (
+      {Object.keys(unplannedByType).length === 0 ? (
         <Alert
           message="Oops!" // might need to change this
           description="It looks like you haven't added any courses to your term planner. Please do so in the course selector."
@@ -40,7 +46,7 @@ const OptionsDrawer = ({ visible, setVisible, unplanned, data }) => {
         />
       ) : (
         <Collapse className="collapse" ghost={theme === "dark"}>
-          {Object.keys(unplanned).map((type, index) => (
+          {Object.keys(unplannedByType).map((type, index) => (
             <Panel header={type} key={index}>
               <Droppable droppableId={type} isDropDisabled={true}>
                 {(provided) => (
@@ -49,13 +55,8 @@ const OptionsDrawer = ({ visible, setVisible, unplanned, data }) => {
                     {...provided.droppableProps}
                     className="panel"
                   >
-                    {unplanned[type].map((code, index) => (
-                      <DraggableCourse
-                        code={code}
-                        index={index}
-                        courseNames={data["courses"]}
-                        key={code}
-                      />
+                    {unplannedByType[type].map((code, index) => (
+                      <DraggableCourse code={code} index={index} key={code} />
                     ))}
                     {provided.placeholder}
                   </div>
@@ -67,6 +68,22 @@ const OptionsDrawer = ({ visible, setVisible, unplanned, data }) => {
       )}
     </Drawer>
   );
+};
+
+// create separate array for each type
+// e.g. courseTypes = { Core: ["COMP1511", "COMP2521"], Elective: ["COMP6881"] }
+const createUnplannedTypes = (unplanned, courses) => {
+  if (unplanned == null) return {};
+  let courseTypes = {};
+  unplanned.forEach((code) => {
+    const type = courses[code]["type"];
+    if (!courseTypes.hasOwnProperty(type)) {
+      courseTypes[type] = [code];
+    } else {
+      courseTypes[type].push(code);
+    }
+  });
+  return courseTypes;
 };
 
 export default OptionsDrawer;

--- a/frontend/src/pages/TermPlanner/SkeletonPlanner.js
+++ b/frontend/src/pages/TermPlanner/SkeletonPlanner.js
@@ -13,27 +13,65 @@ function SkeletonPlanner() {
   };
 
   return (
-    <div className="gridContainer">
-      <div className="gridItem" />
-      <div className="gridItem">Term 1</div>
-      <div className="gridItem">Term 2</div>
-      <div className="gridItem">Term 3</div>
+    <div className="plannerContainer">
+      <div className="gridContainer">
+        <div className="gridItem" />
+        <div className="gridItem">Term 1</div>
+        <div className="gridItem">Term 2</div>
+        <div className="gridItem">Term 3</div>
 
-      <div className="gridItem" />
-      <Skeleton.Button active={true} shape="round" style={skeletonTermStyle} />
-      <Skeleton.Button active={true} shape="round" style={skeletonTermStyle} />
-      <Skeleton.Button active={true} shape="round" style={skeletonTermStyle} />
+        <div className="gridItem" />
+        <Skeleton.Button
+          active={true}
+          shape="round"
+          style={skeletonTermStyle}
+        />
+        <Skeleton.Button
+          active={true}
+          shape="round"
+          style={skeletonTermStyle}
+        />
+        <Skeleton.Button
+          active={true}
+          shape="round"
+          style={skeletonTermStyle}
+        />
 
-      <div className="gridItem" />
-      <Skeleton.Button active={true} shape="round" style={skeletonTermStyle} />
-      <Skeleton.Button active={true} shape="round" style={skeletonTermStyle} />
-      <Skeleton.Button active={true} shape="round" style={skeletonTermStyle} />
+        <div className="gridItem" />
+        <Skeleton.Button
+          active={true}
+          shape="round"
+          style={skeletonTermStyle}
+        />
+        <Skeleton.Button
+          active={true}
+          shape="round"
+          style={skeletonTermStyle}
+        />
+        <Skeleton.Button
+          active={true}
+          shape="round"
+          style={skeletonTermStyle}
+        />
 
-      <div className="gridItem" />
-      <Skeleton.Button active={true} shape="round" style={skeletonTermStyle} />
-      <Skeleton.Button active={true} shape="round" style={skeletonTermStyle} />
-      <Skeleton.Button active={true} shape="round" style={skeletonTermStyle} />
-      {/* <Skeleton.Button style={skeletonTermStyle} className="termBox" /> */}
+        <div className="gridItem" />
+        <Skeleton.Button
+          active={true}
+          shape="round"
+          style={skeletonTermStyle}
+        />
+        <Skeleton.Button
+          active={true}
+          shape="round"
+          style={skeletonTermStyle}
+        />
+        <Skeleton.Button
+          active={true}
+          shape="round"
+          style={skeletonTermStyle}
+        />
+        {/* <Skeleton.Button style={skeletonTermStyle} className="termBox" /> */}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/TermPlanner/TermBox.js
+++ b/frontend/src/pages/TermPlanner/TermBox.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Droppable } from "react-beautiful-dnd";
 import DraggableCourse from "./DraggableCourse";
 
-function TermBox({ name, courses, courseNames, termsOffered, isDragging }) {
+function TermBox({ name, courses, termsOffered, isDragging }) {
   const term = name.match(/t[0-3]/)[0];
   const isDropAllowed = termsOffered.includes(term);
 
@@ -15,12 +15,7 @@ function TermBox({ name, courses, courseNames, termsOffered, isDragging }) {
           className={`termBox ${isDropAllowed && isDragging && "droppable"}  `}
         >
           {courses.map((code, index) => (
-            <DraggableCourse
-              key={code}
-              code={code}
-              index={index}
-              courseNames={courseNames}
-            />
+            <DraggableCourse key={code} code={code} index={index} />
           ))}
           {provided.placeholder}
         </ul>

--- a/frontend/src/pages/TermPlanner/TermBox.js
+++ b/frontend/src/pages/TermPlanner/TermBox.js
@@ -1,15 +1,10 @@
 import React from "react";
 import { Droppable } from "react-beautiful-dnd";
 import DraggableCourse from "./DraggableCourse";
-import { useSelector } from "react-redux";
 
 function TermBox({ name, courses, termsOffered, isDragging }) {
   const term = name.match(/t[0-3]/)[0];
   const isDropAllowed = termsOffered.includes(term);
-
-  const { plannedCourses } = useSelector((state) => {
-    return state.planner;
-  });
 
   return (
     <Droppable droppableId={name} isDropDisabled={!isDropAllowed}>
@@ -19,17 +14,9 @@ function TermBox({ name, courses, termsOffered, isDragging }) {
           {...provided.droppableProps}
           className={`termBox ${isDropAllowed && isDragging && "droppable"}  `}
         >
-          {courses.map((code, index) => {
-            const warning = plannedCourses.get(code)["warning"];
-            return (
-              <DraggableCourse
-                key={code}
-                code={code}
-                index={index}
-                warning={warning}
-              />
-            );
-          })}
+          {courses.map((code, index) => (
+            <DraggableCourse key={code} code={code} index={index} />
+          ))}
           {provided.placeholder}
         </ul>
       )}

--- a/frontend/src/pages/TermPlanner/TermBox.js
+++ b/frontend/src/pages/TermPlanner/TermBox.js
@@ -1,10 +1,15 @@
 import React from "react";
 import { Droppable } from "react-beautiful-dnd";
 import DraggableCourse from "./DraggableCourse";
+import { useSelector } from "react-redux";
 
 function TermBox({ name, courses, termsOffered, isDragging }) {
   const term = name.match(/t[0-3]/)[0];
   const isDropAllowed = termsOffered.includes(term);
+
+  const { plannedCourses } = useSelector((state) => {
+    return state.planner;
+  });
 
   return (
     <Droppable droppableId={name} isDropDisabled={!isDropAllowed}>
@@ -14,9 +19,17 @@ function TermBox({ name, courses, termsOffered, isDragging }) {
           {...provided.droppableProps}
           className={`termBox ${isDropAllowed && isDragging && "droppable"}  `}
         >
-          {courses.map((code, index) => (
-            <DraggableCourse key={code} code={code} index={index} />
-          ))}
+          {courses.map((code, index) => {
+            const warning = plannedCourses.get(code)["warning"];
+            return (
+              <DraggableCourse
+                key={code}
+                code={code}
+                index={index}
+                warning={warning}
+              />
+            );
+          })}
           {provided.placeholder}
         </ul>
       )}

--- a/frontend/src/pages/TermPlanner/main.js
+++ b/frontend/src/pages/TermPlanner/main.js
@@ -14,7 +14,7 @@ const TermPlanner = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [termsOffered, setTermsOffered] = useState([]);
   const [isDragging, setIsDragging] = useState(false);
-  const { years, startYear, courses } = useSelector((state) => {
+  const { years, startYear, courses, plannedCourses } = useSelector((state) => {
     return state.planner;
   });
   const [visible, setVisible] = useState(false); // visibility for side drawer
@@ -30,6 +30,8 @@ const TermPlanner = () => {
     dispatch,
     years,
     startYear,
+    plannedCourses,
+    courses,
   };
 
   return (

--- a/frontend/src/pages/TermPlanner/main.js
+++ b/frontend/src/pages/TermPlanner/main.js
@@ -4,23 +4,19 @@ import { Button, notification } from "antd";
 import { DragDropContext } from "react-beautiful-dnd";
 import TermBox from "./TermBox";
 import { RightOutlined } from "@ant-design/icons";
-import axios from "axios";
 import OptionsDrawer from "./OptionsDrawer";
 import SkeletonPlanner from "./SkeletonPlanner";
 import "./main.less";
 import { useSelector, useDispatch } from "react-redux";
-import { plannerActions } from "../../actions/plannerActions";
 import { handleOnDragEnd, handleOnDragStart } from "./DragDropLogic";
 
 const TermPlanner = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [termsOffered, setTermsOffered] = useState([]);
   const [isDragging, setIsDragging] = useState(false);
-  const { years, startYear, courses, sortedUnplanned } = useSelector(
-    (state) => {
-      return state.planner;
-    }
-  );
+  const { years, startYear, courses } = useSelector((state) => {
+    return state.planner;
+  });
   const [visible, setVisible] = useState(false); // visibility for side drawer
   const dispatch = useDispatch();
 
@@ -32,7 +28,6 @@ const TermPlanner = () => {
   const dragEndProps = {
     setIsDragging,
     dispatch,
-    sortedUnplanned,
     years,
     startYear,
   };

--- a/frontend/src/pages/TermPlanner/main.js
+++ b/frontend/src/pages/TermPlanner/main.js
@@ -10,106 +10,31 @@ import SkeletonPlanner from "./SkeletonPlanner";
 import "./main.less";
 import { useSelector, useDispatch } from "react-redux";
 import { plannerActions } from "../../actions/plannerActions";
+import { handleOnDragEnd, handleOnDragStart } from "./DragDropLogic";
 
 const TermPlanner = () => {
-  const [data, setData] = useState({});
   const [isLoading, setIsLoading] = useState(true);
-  const [unplanned, setUnplanned] = useState({});
-  const { years, startYear, courses } = useSelector((state) => {
-    return state.planner;
-  });
-  console.log(courses.get("DEFAULT1000"));
-
-  const dispatch = useDispatch();
-  const fetchCourses = async () => {
-    const res = await axios.get("data.json");
-    setData(res.data);
-    //     setYears(res.data.years);
-    setUnplanned(createUnplannedTypes(res.data));
-    setIsLoading(false);
-    isAllEmpty(years) && openNotification();
-  };
-
-  useEffect(() => {
-    setTimeout(fetchCourses, 1000); // testing skeleton
-  }, []);
-
-  // visibility for side drawer
-  const [visible, setVisible] = useState(false);
-
-  const handleOnDragEnd = (result) => {
-    setIsDragging(false);
-
-    const { destination, source, draggableId } = result;
-    let newYears = [...years];
-
-    if (!destination) return; // drag outside container
-    if (
-      destination.droppableId === source.droppableId &&
-      destination.index === source.index
-    )
-      // drag to same place
-      return;
-
-    const destYear = destination.droppableId.match(/[0-9]{4}/)[0];
-    const destTerm = destination.droppableId.match(/t[1-3]/)[0];
-    const destRow = destYear - startYear;
-    const destBox = years[destRow][destTerm];
-
-    // === move unplanned course to term ===
-    if (source.droppableId.match(/[0-9]{4}/) === null) {
-      // updated unplanned list
-      const type = source.droppableId;
-      const code = unplanned[type][source.index];
-      const unplannedCpy = Object.assign({}, unplanned);
-      unplannedCpy[type] = unplannedCpy[type].filter(
-        (course) => course !== code
-      );
-      setUnplanned(unplannedCpy);
-
-      // update destination term box
-      const destCoursesCpy = Array.from(years[destRow][destTerm]);
-      destCoursesCpy.splice(destination.index, 0, draggableId);
-      newYears[destRow][destTerm] = destCoursesCpy;
-      dispatch(plannerActions("SET_YEARS", newYears));
-      return;
-    }
-
-    const srcYear = source.droppableId.match(/[0-9]{4}/)[0];
-    const srcTerm = source.droppableId.match(/t[1-3]/)[0];
-    const srcRow = srcYear - startYear;
-    const srcBox = years[srcRow][srcTerm];
-
-    // === move within one term ===
-    if (srcBox === destBox) {
-      const alteredBox = Array.from(srcBox);
-      alteredBox.splice(source.index, 1);
-      alteredBox.splice(destination.index, 0, draggableId);
-      newYears[srcRow][srcTerm] = alteredBox;
-      dispatch(plannerActions("SET_YEARS", newYears));
-      return;
-    }
-
-    // === move from one term to another ===
-    const srcCoursesCpy = Array.from(years[srcRow][srcTerm]);
-    srcCoursesCpy.splice(source.index, 1);
-
-    const destCoursesCpy = Array.from(years[destRow][destTerm]);
-    destCoursesCpy.splice(destination.index, 0, draggableId);
-
-    newYears[srcRow][srcTerm] = srcCoursesCpy;
-    newYears[destRow][destTerm] = destCoursesCpy;
-
-    dispatch(plannerActions("SET_YEARS", newYears));
-  };
-
   const [termsOffered, setTermsOffered] = useState([]);
   const [isDragging, setIsDragging] = useState(false);
-  const handleOnDragStart = (courseItem) => {
-    setIsDragging(true);
-    const course = courseItem.draggableId;
-    const terms = courses.get(course)["termsOffered"];
-    setTermsOffered(terms);
+  const { years, startYear, courses, sortedUnplanned } = useSelector(
+    (state) => {
+      return state.planner;
+    }
+  );
+  const [visible, setVisible] = useState(false); // visibility for side drawer
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    setIsLoading(false);
+    isAllEmpty(years) && openNotification();
+  }, []);
+
+  const dragEndProps = {
+    setIsDragging,
+    dispatch,
+    sortedUnplanned,
+    years,
+    startYear,
   };
 
   return (
@@ -118,8 +43,10 @@ const TermPlanner = () => {
         <SkeletonPlanner />
       ) : (
         <DragDropContext
-          onDragEnd={handleOnDragEnd}
-          onDragStart={handleOnDragStart}
+          onDragEnd={(result) => handleOnDragEnd(result, dragEndProps)}
+          onDragStart={(result) =>
+            handleOnDragStart(result, courses, setTermsOffered, setIsDragging)
+          }
         >
           <div className="plannerContainer">
             <Button
@@ -153,11 +80,7 @@ const TermPlanner = () => {
                 </React.Fragment>
               ))}
             </div>
-            <OptionsDrawer
-              visible={visible}
-              setVisible={setVisible}
-              unplanned={unplanned}
-            />
+            <OptionsDrawer visible={visible} setVisible={setVisible} />
           </div>
         </DragDropContext>
       )}
@@ -175,22 +98,6 @@ const openNotification = () => {
     placement: "topRight",
   };
   notification["info"](args);
-};
-
-// create separate array for each type
-// e.g. courseTypes = { Core: ["COMP1511", "COMP2521"], Elective: ["COMP6881"] }
-const createUnplannedTypes = (data) => {
-  if (data["unplanned"] == null) return {};
-  let courseTypes = {};
-  data["unplanned"].forEach((code) => {
-    const type = data["courses"][code]["type"];
-    if (!courseTypes.hasOwnProperty(type)) {
-      courseTypes[type] = [code];
-    } else {
-      courseTypes[type].push(code);
-    }
-  });
-  return courseTypes;
 };
 
 // checks if no courses have been planned (to display help notification)

--- a/frontend/src/pages/TermPlanner/main.js
+++ b/frontend/src/pages/TermPlanner/main.js
@@ -18,9 +18,9 @@ const TermPlanner = () => {
   const { years, startYear, courses } = useSelector((state) => {
     return state.planner;
   });
+  console.log(courses.get("DEFAULT1000"));
 
   const dispatch = useDispatch();
-
   const fetchCourses = async () => {
     const res = await axios.get("data.json");
     setData(res.data);
@@ -32,7 +32,6 @@ const TermPlanner = () => {
 
   useEffect(() => {
     setTimeout(fetchCourses, 1000); // testing skeleton
-    //     fetchCourses();
   }, []);
 
   // visibility for side drawer
@@ -54,8 +53,8 @@ const TermPlanner = () => {
 
     const destYear = destination.droppableId.match(/[0-9]{4}/)[0];
     const destTerm = destination.droppableId.match(/t[1-3]/)[0];
-    const destIndex = destYear - startYear;
-    const destBox = years[destIndex][destTerm];
+    const destRow = destYear - startYear;
+    const destBox = years[destRow][destTerm];
 
     // === move unplanned course to term ===
     if (source.droppableId.match(/[0-9]{4}/) === null) {
@@ -69,37 +68,37 @@ const TermPlanner = () => {
       setUnplanned(unplannedCpy);
 
       // update destination term box
-      const destCoursesCpy = Array.from(years[destIndex][destTerm]);
+      const destCoursesCpy = Array.from(years[destRow][destTerm]);
       destCoursesCpy.splice(destination.index, 0, draggableId);
-      newYears[destIndex][destTerm] = destCoursesCpy;
+      newYears[destRow][destTerm] = destCoursesCpy;
       dispatch(plannerActions("SET_YEARS", newYears));
       return;
     }
 
     const srcYear = source.droppableId.match(/[0-9]{4}/)[0];
     const srcTerm = source.droppableId.match(/t[1-3]/)[0];
-    const srcIndex = srcYear - startYear;
-    const srcBox = years[srcIndex][srcTerm];
+    const srcRow = srcYear - startYear;
+    const srcBox = years[srcRow][srcTerm];
 
     // === move within one term ===
     if (srcBox === destBox) {
       const alteredBox = Array.from(srcBox);
       alteredBox.splice(source.index, 1);
       alteredBox.splice(destination.index, 0, draggableId);
-      newYears[srcIndex][srcTerm] = alteredBox;
+      newYears[srcRow][srcTerm] = alteredBox;
       dispatch(plannerActions("SET_YEARS", newYears));
       return;
     }
 
     // === move from one term to another ===
-    const srcCoursesCpy = Array.from(years[srcIndex][srcTerm]);
+    const srcCoursesCpy = Array.from(years[srcRow][srcTerm]);
     srcCoursesCpy.splice(source.index, 1);
 
-    const destCoursesCpy = Array.from(years[destIndex][destTerm]);
+    const destCoursesCpy = Array.from(years[destRow][destTerm]);
     destCoursesCpy.splice(destination.index, 0, draggableId);
 
-    newYears[srcIndex][srcTerm] = srcCoursesCpy;
-    newYears[destIndex][destTerm] = destCoursesCpy;
+    newYears[srcRow][srcTerm] = srcCoursesCpy;
+    newYears[destRow][destTerm] = destCoursesCpy;
 
     dispatch(plannerActions("SET_YEARS", newYears));
   };
@@ -109,7 +108,7 @@ const TermPlanner = () => {
   const handleOnDragStart = (courseItem) => {
     setIsDragging(true);
     const course = courseItem.draggableId;
-    const terms = courses[course]["termsOffered"];
+    const terms = courses.get(course)["termsOffered"];
     setTermsOffered(terms);
   };
 

--- a/frontend/src/pages/TermPlanner/main.js
+++ b/frontend/src/pages/TermPlanner/main.js
@@ -14,7 +14,7 @@ const TermPlanner = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [termsOffered, setTermsOffered] = useState([]);
   const [isDragging, setIsDragging] = useState(false);
-  const { years, startYear, courses, plannedCourses } = useSelector((state) => {
+  const { years, startYear, courses } = useSelector((state) => {
     return state.planner;
   });
   const [visible, setVisible] = useState(false); // visibility for side drawer
@@ -30,8 +30,6 @@ const TermPlanner = () => {
     dispatch,
     years,
     startYear,
-    plannedCourses,
-    courses,
   };
 
   return (

--- a/frontend/src/pages/TermPlanner/main.less
+++ b/frontend/src/pages/TermPlanner/main.less
@@ -30,14 +30,20 @@
   .course {
     font-size: 0.8rem;
     cursor: pointer;
-    padding: 0.7em;
-    padding-right: 1em;
-    padding-left: 1em;
+    padding: 0.9em;
+    padding-right: 1.1em;
+    padding-left: 1.1em;
     border-radius: 1em;
     max-width: 20em;
     min-width: 12em;
     margin-top: 1em;
+
+	display: flex;
+	gap: 0.5em;
+	align-items: center;
   }
+
+
 
   .panel {
     max-height: 30em;
@@ -73,6 +79,10 @@
   .course {
     background-color: #9254de;
   }
+  .warning {
+	background-color: #F2B25C;
+  }
+
 
   .droppable {
     background-color: #333738;
@@ -124,6 +134,9 @@
 .light {
   .course {
     background-color: #d9d9d9;
+  }
+  .warning {
+	background-color: #FFE8C3;
   }
 
   .termBox {

--- a/frontend/src/pages/TermPlanner/main.less
+++ b/frontend/src/pages/TermPlanner/main.less
@@ -30,20 +30,14 @@
   .course {
     font-size: 0.8rem;
     cursor: pointer;
-    padding: 0.9em;
-    padding-right: 1.1em;
-    padding-left: 1.1em;
+    padding: 0.7em;
+    padding-right: 1em;
+    padding-left: 1em;
     border-radius: 1em;
     max-width: 20em;
     min-width: 12em;
     margin-top: 1em;
-
-	display: flex;
-	gap: 0.5em;
-	align-items: center;
   }
-
-
 
   .panel {
     max-height: 30em;
@@ -79,10 +73,6 @@
   .course {
     background-color: #9254de;
   }
-  .warning {
-	background-color: #F2B25C;
-  }
-
 
   .droppable {
     background-color: #333738;
@@ -134,9 +124,6 @@
 .light {
   .course {
     background-color: #d9d9d9;
-  }
-  .warning {
-	background-color: #FFE8C3;
   }
 
   .termBox {

--- a/frontend/src/reducers/index.js
+++ b/frontend/src/reducers/index.js
@@ -2,10 +2,13 @@ import { combineReducers } from "redux";
 import themeReducer from "./themeReducer";
 import updateCourses from "./updateCourses";
 import userReducer from "./userReducer";
+import plannerReducer from "./plannerReducer";
+
 const allReducers = combineReducers({
   updateCourses: updateCourses,
   user: userReducer,
   theme: themeReducer,
+  planner: plannerReducer,
 });
 
 export default allReducers;

--- a/frontend/src/reducers/plannerReducer.js
+++ b/frontend/src/reducers/plannerReducer.js
@@ -6,12 +6,17 @@ dummyMap.set("DEFAULT1000", {
 });
 dummyMap.set("DEFAULT2000", {
   title: "Default course 2",
-  type: "Core",
+  type: "Elective",
   termsOffered: ["t1", "t2"],
+});
+dummyMap.set("DEFAULT3000", {
+  title: "Default course 3",
+  type: "General Education",
+  termsOffered: ["t2", "t3"],
 });
 
 const initialState = {
-  unplanned: ["DEFAULT1000", "DEFAULT2000"],
+  unplanned: ["DEFAULT1000", "DEFAULT2000", "DEFAULT3000"],
   startYear: 2021,
   numYears: 3,
   years: [
@@ -32,7 +37,6 @@ const plannerReducer = (state = initialState, action) => {
 
       // Append course code onto unplanned
       state.unplanned.join(courseCode);
-      console.log(state);
       return state;
     default:
       return state;

--- a/frontend/src/reducers/plannerReducer.js
+++ b/frontend/src/reducers/plannerReducer.js
@@ -17,6 +17,7 @@ dummyMap.set("DEFAULT3000", {
 
 const initialState = {
   unplanned: ["DEFAULT1000", "DEFAULT2000", "DEFAULT3000"],
+  sortedUnplanned: {},
   startYear: 2021,
   numYears: 3,
   years: [
@@ -38,6 +39,24 @@ const plannerReducer = (state = initialState, action) => {
       // Append course code onto unplanned
       state.unplanned.join(courseCode);
       return state;
+    case "SET_YEARS":
+      return { ...state, years: action.payload };
+    case "SET_SORTED_UNPLANNED":
+      const sortedUnplanned = action.payload;
+      let unplanned = [];
+      for (let key in sortedUnplanned) {
+        let type = sortedUnplanned[key];
+        type.forEach((course) => {
+          unplanned.push(course);
+        });
+      }
+      console.log(unplanned);
+
+      return {
+        ...state,
+        sortedUnplanned: action.payload,
+        unplanned: unplanned,
+      };
     default:
       return state;
   }

--- a/frontend/src/reducers/plannerReducer.js
+++ b/frontend/src/reducers/plannerReducer.js
@@ -1,0 +1,113 @@
+const initialState = {
+  unplanned: [
+    "COMP1511",
+    "MATH1131",
+    "COMP3331",
+    "ENGG1000",
+    "COMP2041",
+    "COMP3311",
+    "COMP3601",
+  ],
+  //   unplanned: new Map(),
+  planned: new Map(),
+  startYear: 2021,
+  numYears: 3,
+  years: [
+    { t1: [], t2: [], t3: [] },
+    { t1: [], t2: [], t3: [] },
+    { t1: [], t2: [], t3: [] },
+  ],
+  courses: {
+    COMP3821: {
+      title: "Extended algorithms and programming techniques",
+      type: "Core",
+      termsOffered: ["t1"],
+    },
+    ARTS4268: {
+      title: "Methodologies in the Social Sciences: Questions and Quandaries",
+      type: "General Education",
+      termsOffered: ["t1", "t2"],
+    },
+    COMP1511: {
+      title: "Programming Fundamentals",
+      type: "Core",
+      termsOffered: ["t1", "t2", "t3"],
+    },
+    CHEM1011: {
+      title: "Chemistry 1A",
+      type: "Elective",
+      termsOffered: ["t1", "t2", "t3"],
+    },
+    MATH1131: {
+      title: "Mathematics 1A",
+      type: "Core",
+      termsOffered: ["t1", "t2", "t3"],
+    },
+    BIOC2201: {
+      title: "Biochemistry",
+      type: "Elective",
+      termsOffered: ["t3"],
+    },
+    ENGG1000: {
+      title: "Introduction to Engineering Design and Innovation",
+      type: "Core",
+      termsOffered: ["t1", "t3"],
+    },
+    COMP2041: {
+      title: "Software Construction: Techniques and Tools",
+      type: "Core",
+      termsOffered: ["t1"],
+    },
+    COMP4441: {
+      title: "Random Course",
+      type: "General Education",
+      termsOffered: ["t1", "t2", "t3"],
+    },
+    COMP3131: {
+      title: "Programming Languages and Compilers",
+      type: "Elective",
+      termsOffered: ["t3"],
+    },
+    COMP3601: {
+      title: "Design Project A",
+      type: "Elective",
+      termsOffered: ["t1", "t2"],
+    },
+    COMP3331: {
+      title: "Computer Networks and Applications",
+      type: "Core",
+      termsOffered: ["t1", "t2", "t3"],
+    },
+    COMP3311: {
+      title: "Database Systems",
+      type: "Core",
+      termsOffered: ["t1", "t3"],
+    },
+  },
+};
+const plannerReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case "SET_COURSES":
+      return { ...state, initialCourses: action.payload };
+    case "SET_COURSE":
+      return { ...state, course: action.payload };
+
+    case "DELETE":
+      return state.filter((value, index) => {
+        return value !== action.payload;
+      });
+    default:
+      return state;
+    //     case "ADD_UNPLANNED":
+    //       console.log("adding course to planner", action.payload);
+    //       return {
+    //         ...state,
+    //         unplanned: state.unplanned.set(
+    //           action.payload.courseCode,
+    //           action.payload.courseData
+    //         ),
+    //       };
+  }
+};
+
+export default plannerReducer;

--- a/frontend/src/reducers/plannerReducer.js
+++ b/frontend/src/reducers/plannerReducer.js
@@ -1,22 +1,36 @@
 const dummyMap = new Map();
-dummyMap.set("DEFAULT1000", {
-  title: "Default course 1",
+
+dummyMap.set("COMP1511", {
+  title: "Programming Fundamentals",
   type: "Core",
-  termsOffered: ["t1", "t2"],
+  termsOffered: ["t1", "t2", "t3"],
+  prereqs: [],
+});
+dummyMap.set("COMP2521", {
+  title: "Data Structures and Algorithms",
+  type: "Core",
+  termsOffered: ["t1", "t2", "t3"],
+  prereqs: ["COMP1511"],
 });
 dummyMap.set("DEFAULT2000", {
   title: "Default course 2",
   type: "Elective",
   termsOffered: ["t1", "t2"],
+  prereqs: ["COMP1511"],
 });
 dummyMap.set("DEFAULT3000", {
   title: "Default course 3",
   type: "General Education",
   termsOffered: ["t2", "t3"],
+  prereqs: ["COMP1511"],
 });
 
+const plannedCourses = new Map();
+// plannedCourses.set("COMP2511", "2021t1");
+// plannedCourses.set("COMP1511", "2021t2");
+
 const initialState = {
-  unplanned: ["DEFAULT1000", "DEFAULT2000", "DEFAULT3000"],
+  unplanned: ["COMP1511", "COMP2521", "DEFAULT2000", "DEFAULT3000"],
   startYear: 2021,
   numYears: 3,
   years: [
@@ -25,6 +39,7 @@ const initialState = {
     { t1: [], t2: [], t3: [] },
   ],
   courses: dummyMap,
+  plannedCourses: plannedCourses,
 };
 const plannerReducer = (state = initialState, action) => {
   switch (action.type) {
@@ -47,9 +62,21 @@ const plannerReducer = (state = initialState, action) => {
       state.unplanned.forEach((course) => {
         if (action.payload != course) newUnplanned.push(course);
       });
-      console.log(newUnplanned);
 
       return { ...state, unplanned: newUnplanned };
+
+    case "UPDATE_PLANNED_COURSES":
+      //       let plannedCourses = = [];
+      //       state.unplanned.forEach((course) => {
+      //         if (action.payload != course) newUnplanned.push(course);
+      //       });
+      //       console.log(newUnplanned);
+      const { course, term, warning } = action.payload;
+      const plannedClone = new Map(state.plannedCourses).set(course, {
+        term: term,
+        warning: warning,
+      });
+      return { ...state, plannedCourses: plannedClone };
 
     default:
       return state;

--- a/frontend/src/reducers/plannerReducer.js
+++ b/frontend/src/reducers/plannerReducer.js
@@ -17,7 +17,6 @@ dummyMap.set("DEFAULT3000", {
 
 const initialState = {
   unplanned: ["DEFAULT1000", "DEFAULT2000", "DEFAULT3000"],
-  sortedUnplanned: {},
   startYear: 2021,
   numYears: 3,
   years: [
@@ -39,24 +38,19 @@ const plannerReducer = (state = initialState, action) => {
       // Append course code onto unplanned
       state.unplanned.join(courseCode);
       return state;
+
     case "SET_YEARS":
       return { ...state, years: action.payload };
-    case "SET_SORTED_UNPLANNED":
-      const sortedUnplanned = action.payload;
-      let unplanned = [];
-      for (let key in sortedUnplanned) {
-        let type = sortedUnplanned[key];
-        type.forEach((course) => {
-          unplanned.push(course);
-        });
-      }
-      console.log(unplanned);
 
-      return {
-        ...state,
-        sortedUnplanned: action.payload,
-        unplanned: unplanned,
-      };
+    case "SET_UNPLANNED":
+      let newUnplanned = [];
+      state.unplanned.forEach((course) => {
+        if (action.payload != course) newUnplanned.push(course);
+      });
+      console.log(newUnplanned);
+
+      return { ...state, unplanned: newUnplanned };
+
     default:
       return state;
   }

--- a/frontend/src/reducers/plannerReducer.js
+++ b/frontend/src/reducers/plannerReducer.js
@@ -1,36 +1,22 @@
 const dummyMap = new Map();
-
-dummyMap.set("COMP1511", {
-  title: "Programming Fundamentals",
+dummyMap.set("DEFAULT1000", {
+  title: "Default course 1",
   type: "Core",
-  termsOffered: ["t1", "t2", "t3"],
-  prereqs: [],
-});
-dummyMap.set("COMP2521", {
-  title: "Data Structures and Algorithms",
-  type: "Core",
-  termsOffered: ["t1", "t2", "t3"],
-  prereqs: ["COMP1511"],
+  termsOffered: ["t1", "t2"],
 });
 dummyMap.set("DEFAULT2000", {
   title: "Default course 2",
   type: "Elective",
   termsOffered: ["t1", "t2"],
-  prereqs: ["COMP1511"],
 });
 dummyMap.set("DEFAULT3000", {
   title: "Default course 3",
   type: "General Education",
   termsOffered: ["t2", "t3"],
-  prereqs: ["COMP1511"],
 });
 
-const plannedCourses = new Map();
-// plannedCourses.set("COMP2511", "2021t1");
-// plannedCourses.set("COMP1511", "2021t2");
-
 const initialState = {
-  unplanned: ["COMP1511", "COMP2521", "DEFAULT2000", "DEFAULT3000"],
+  unplanned: ["DEFAULT1000", "DEFAULT2000", "DEFAULT3000"],
   startYear: 2021,
   numYears: 3,
   years: [
@@ -39,7 +25,6 @@ const initialState = {
     { t1: [], t2: [], t3: [] },
   ],
   courses: dummyMap,
-  plannedCourses: plannedCourses,
 };
 const plannerReducer = (state = initialState, action) => {
   switch (action.type) {
@@ -62,21 +47,9 @@ const plannerReducer = (state = initialState, action) => {
       state.unplanned.forEach((course) => {
         if (action.payload != course) newUnplanned.push(course);
       });
+      console.log(newUnplanned);
 
       return { ...state, unplanned: newUnplanned };
-
-    case "UPDATE_PLANNED_COURSES":
-      //       let plannedCourses = = [];
-      //       state.unplanned.forEach((course) => {
-      //         if (action.payload != course) newUnplanned.push(course);
-      //       });
-      //       console.log(newUnplanned);
-      const { course, term, warning } = action.payload;
-      const plannedClone = new Map(state.plannedCourses).set(course, {
-        term: term,
-        warning: warning,
-      });
-      return { ...state, plannedCourses: plannedClone };
 
     default:
       return state;


### PR DESCRIPTION
CIRCLES-175

- term planner no longer grabs data from json file (instead from redux store)
- large drag functions have been moved to a separate file to keep main.js cleaner
- new redux actions (set_years and set_unplanned) keep redux store updated when courses are moved around in term planner
