### PR TITLE
[ab/process spns] Expands specialisations processing to COMP minors

### DIFF
--- a/backend/data/finalData/specialisationsProcessed.json
+++ b/backend/data/finalData/specialisationsProcessed.json
@@ -43,7 +43,7 @@
                 "credits_to_complete": 30,
                 "type": "elective",
                 "levels": [],
-                "notes": "<br />NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. <br />2 UOC courses are run over consecutive terms for a final total of 6 UOC."
+                "notes": "NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. 2 UOC courses are run over consecutive terms for a final total of 6 UOC."
             }
         ]
     },
@@ -94,7 +94,7 @@
         "course_constraints": [
             {
                 "title": "Level 4 UOC Minimum",
-                "description": "Students must complete a minimum of 36 UOC of Level 4 courses including core courses and at least 12 UOC of Level 4 Discipline Electives, including:<br /><br />COMP4601 - Design Project B<br />COMP4920 - Management and Ethics<br />COMP4951 - Research Thesis A<br />COMP4952 - Research Thesis B<br />COMP4953 - Research Thesis C<br />any level 4 course offered by School of Computer Science and Engineering<br />"
+                "description": "Students must complete a minimum of 36 UOC of Level 4 courses including core courses and at least 12 UOC of Level 4 Discipline Electives, including: COMP4601 - Design Project B COMP4920 - Management and Ethics COMP4951 - Research Thesis A COMP4952 - Research Thesis B COMP4953 - Research Thesis C any level 4 course offered by School of Computer Science and Engineering"
             }
         ],
         "curriculum": [
@@ -113,7 +113,7 @@
                 "credits_to_complete": 24,
                 "type": "elective",
                 "levels": [],
-                "notes": "<br /><br />2 UOC and 3 UOC courses are run over consecutive terms for a final total of 6 UOC."
+                "notes": "2 UOC and 3 UOC courses are run over consecutive terms for a final total of 6 UOC."
             },
             {
                 "courses": {
@@ -197,7 +197,7 @@
         "course_constraints": [
             {
                 "title": "Level 4 (or higher) COMP UOC Minimum",
-                "description": "Students must complete a minimum of 30 UOC of the following courses.<br /><br />COMP4920 - Management and Ethics<br />any level 4 Computer Science (COMP) course<br />any level 6 Computer Science (COMP) course<br />any level 9 Computer Science (COMP) course<br />COMP4951 - Research Thesis A<br />COMP4952 - Research Thesis B<br />COMP4953 - Research Thesis C<br />"
+                "description": "Students must complete a minimum of 30 UOC of the following courses. COMP4920 - Management and Ethics any level 4 Computer Science (COMP) course any level 6 Computer Science (COMP) course any level 9 Computer Science (COMP) course COMP4951 - Research Thesis A COMP4952 - Research Thesis B COMP4953 - Research Thesis C"
             }
         ],
         "curriculum": [
@@ -365,7 +365,7 @@
                 "credits_to_complete": 6,
                 "type": "elective",
                 "levels": [],
-                "notes": "<br />NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. <br />2 UOC courses are run over consecutive terms for a final total of 6 UOC."
+                "notes": "NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. 2 UOC courses are run over consecutive terms for a final total of 6 UOC."
             }
         ]
     },
@@ -393,7 +393,7 @@
                 "credits_to_complete": 6,
                 "type": "elective",
                 "levels": [],
-                "notes": "<br />NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. <br />2 UOC courses are run over consecutive terms for a final total of 6 UOC."
+                "notes": "NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. 2 UOC courses are run over consecutive terms for a final total of 6 UOC."
             },
             {
                 "courses": {
@@ -471,7 +471,7 @@
                 "credits_to_complete": 6,
                 "type": "elective",
                 "levels": [],
-                "notes": "<br />NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. <br />2 UOC courses are run over consecutive terms for a final total of 6 UOC."
+                "notes": "NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. 2 UOC courses are run over consecutive terms for a final total of 6 UOC."
             },
             {
                 "courses": {
@@ -554,7 +554,7 @@
                 "credits_to_complete": 6,
                 "type": "elective",
                 "levels": [],
-                "notes": "<br />NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. <br />2 UOC courses are run over consecutive terms for a final total of 6 UOC."
+                "notes": "NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. 2 UOC courses are run over consecutive terms for a final total of 6 UOC."
             }
         ]
     },
@@ -582,7 +582,7 @@
                 "credits_to_complete": 6,
                 "type": "elective",
                 "levels": [],
-                "notes": "<br />NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. <br />2 UOC courses are run over consecutive terms for a final total of 6 UOC."
+                "notes": "NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. 2 UOC courses are run over consecutive terms for a final total of 6 UOC."
             },
             {
                 "courses": {
@@ -681,7 +681,7 @@
         "course_constraints": [
             {
                 "title": "Prescribed Electives Requirement",
-                "description": "Students must complete a minimum of 6 UOC of the following courses.<br /><br />COMP6445 - Digital Forensics<br />COMP6845 - Extended Digital Forensics and Incident Response<br />COMP6447 - System and Software Security Assessment<br />COMP6449 - Security Engineering Professional Practice<br />"
+                "description": "Students must complete a minimum of 6 UOC of the following courses. COMP6445 - Digital Forensics COMP6845 - Extended Digital Forensics and Incident Response COMP6447 - System and Software Security Assessment COMP6449 - Security Engineering Professional Practice"
             }
         ],
         "curriculum": [
@@ -719,7 +719,7 @@
                 "credits_to_complete": 6,
                 "type": "elective",
                 "levels": [],
-                "notes": "<br />NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. <br />2 UOC courses are run over consecutive terms for a final total of 6 UOC."
+                "notes": "NOTE: A student may take up to 6 UOC of VIP courses (ENGG2600, ENG3600, ENG4600) as a computing elective. Counting further VIP courses as computing electives is only possible if approved by the Program Authority (ENG SSS) and Deputy Head of School. 2 UOC courses are run over consecutive terms for a final total of 6 UOC."
             },
             {
                 "courses": {
@@ -942,7 +942,7 @@
                 "credits_to_complete": 12,
                 "type": "elective",
                 "levels": [],
-                "notes": " and may only count ONE Financial Technology course (FINS3645, FINS3646, FINS3647 or FINS3648) towards their minor in Finance."
+                "notes": "and may only count ONE Financial Technology course (FINS3645, FINS3646, FINS3647 or FINS3648) towards their minor in Finance."
             },
             {
                 "courses": {
@@ -986,7 +986,7 @@
                 "credits_to_complete": 30,
                 "type": "core",
                 "levels": [],
-                "notes": " <br /><br />Students in Actuarial degrees should complete MATH1151 or MATH1251 instead of COMM1190. All other students should complete COMM1190.<br /><br />Please note: Courses completed under a minor cannot form part of a nominated major."
+                "notes": "Students in Actuarial degrees should complete MATH1151 or MATH1251 instead of COMM1190. All other students should complete COMM1190. Please note: Courses completed under a minor cannot form part of a nominated major."
             }
         ]
     },
@@ -1014,7 +1014,7 @@
                 "credits_to_complete": 12,
                 "type": "core",
                 "levels": [],
-                "notes": "<br /><br />Students in Comm/Econ and Comm/Actl should take COMM1900 instead of COMM1100. Students in Econ and Actl should take ECON1101. All other students should complete COMM1100"
+                "notes": "Students in Comm/Econ and Comm/Actl should take COMM1900 instead of COMM1100. Students in Econ and Actl should take ECON1101. All other students should complete COMM1100"
             },
             {
                 "courses": {
@@ -1039,7 +1039,7 @@
                 "credits_to_complete": 18,
                 "type": "elective",
                 "levels": [],
-                "notes": " <br />At least one of the elective courses must be at level 3 (i.e. MARK3XXX)). The minor does not form part of the nominated major."
+                "notes": "At least one of the elective courses must be at level 3 (i.e. MARK3XXX)). The minor does not form part of the nominated major."
             }
         ]
     },
@@ -1057,11 +1057,11 @@
         "course_constraints": [
             {
                 "title": "Level 2/3 Mathematics Electives",
-                "description": "Students must complete a minimum of 6 UOC of the following courses.<br /><br />any level 3 Mathematics (MATH) course<br />any level 5 Mathematics (MATH) course<br />any level 6 Mathematics (MATH) course<br />"
+                "description": "Students must complete a minimum of 6 UOC of the following courses. any level 3 Mathematics (MATH) course any level 5 Mathematics (MATH) course any level 6 Mathematics (MATH) course"
             },
             {
                 "title": "Non-statistics Mathematics Courses",
-                "description": "Students may not undertake any of the following higher statistics mathematics courses.<br /><br />any course matching the pattern MATH58##<br />any course matching the pattern MATH59##<br />"
+                "description": "Students may not undertake any of the following higher statistics mathematics courses. any course matching the pattern MATH58## any course matching the pattern MATH59##"
             }
         ],
         "curriculum": [

--- a/backend/data/processors/specialisationsProcessing.py
+++ b/backend/data/processors/specialisationsProcessing.py
@@ -87,8 +87,14 @@ def get_constraint(constraint_data: dict) -> dict:
     """
     return {
         "title": constraint_data["title"],
-        "description": constraint_data["description"]
+        "description": strip_tags(constraint_data["description"])
     }
+
+def strip_tags(text):
+    """ Strips HTML tags """
+    text = re.sub(r"<[^>]*?/>", " ", text)
+    text = re.sub(r" +", " ", text)
+    return text.strip()
 
 def initialise_spn(spn: dict, data: dict) -> None:
     """
@@ -163,7 +169,7 @@ def get_notes(description: str) -> str:
     # Non-greedy search to catch anything after first matching line
     res = re.search(r"Students must.*?following courses\.?([^.].+)", description)
     if res: # Unique notes found
-        return res.group(1)
+        return strip_tags(res.group(1))
     else:
         return ""
 


### PR DESCRIPTION
Expands processing code to COMP minors. I have cross-checked with handbook and they appear to be correct. 

Incidental changes made to get_levels function to take into account "Level X/Y" and to get_notes regex to make it more robust.

Note that manual fixes may be needed for the "notes" and "constraints" fields, presuming that they are used as text pop-ups.