### PR TITLE
CIRCLES-264: no longer require UOC

### DIFF
--- a/backend/algorithms/objects/user.py
+++ b/backend/algorithms/objects/user.py
@@ -72,29 +72,14 @@ class User:
         self.specialisations = copy.deepcopy(data['specialisations'])
         self.courses = copy.deepcopy(data['courses'])
         self.year = copy.deepcopy(data['year'])
-        '''calculate wam and uoc'''
-        # Subtract uoc of the courses without mark when dividing
-        uocfixer = 0
-        for c in self.courses:
-            self.uoc += self.courses[c][0]
-            if type(self.courses[c][1]) != type(1):
-                uocfixer += self.courses[c][0]
-                continue
-            if self.wam is None:
-                self.wam = 0
-            self.wam += self.courses[c][0] * self.courses[c][1]
-        if self.wam is not None:
-            self.wam /= (self.uoc - uocfixer)
-        
-        return
+        self.update_wam_uoc()
 
     def get_grade(self, course):
         '''Given a course which the student has taken, returns their grade (or None for no grade)'''
         return self.courses[course][1]
 
     def update_wam_uoc(self):
-        """Calculates and sets the overall wam and uoc of the user from their courses. 
-        NOTE: This actually changes the user's wam, not simply a getter method"""
+        """Calculates and sets the overall wam and uoc of the user from their courses """
         if not self.courses:
             self.wam = None
             self.uoc = 0

--- a/backend/server/routers/courses.py
+++ b/backend/server/routers/courses.py
@@ -116,7 +116,7 @@ def getAllUnlocked(userData: UserData):
 
     coursesState = {}
 
-    user = User(fixUserData(userData))
+    user = User(fixUserData(userData.dict()))
     for course, condition in CONDITIONS.items():
         # Condition object exists for this course
         state = condition.is_unlocked(user) if condition else {'result': True, 'warnings': []}


### PR DESCRIPTION
you may now use either notation for userData, eg:
```
{
    "program": "3778",
    "specialisations": ["COMPA1"],
    "courses": {
			"COMP1511": 100,
			"COMP1521": [6, 30]
		},
    "year": 0
}
```
The 100 here represents wam for a course.