### PR TITLE
CF-90: Selecting course into sidebar (and UOC badge)

### DIFF
--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -50,20 +50,17 @@ body {
 // Scrollbar settings
 /* width */
 ::-webkit-scrollbar {
-  width: 5px;
+  width: 12px;               /* width of the entire scrollbar */
 }
 
-/* Track */
 ::-webkit-scrollbar-track {
-  background: #efdbff; 
-}
- 
-/* Handle */
-::-webkit-scrollbar-thumb {
-  background: #888; 
+  background: #FAFAFA;        /* color of the tracking area */
 }
 
-/* Handle on hover */
-::-webkit-scrollbar-thumb:hover {
-  background: #555; 
+::-webkit-scrollbar-thumb {
+  background-color: #C2C2C2;    /* color of the scroll thumb */
+  border-radius: 20px;       /* roundness of the scroll thumb */
+  border: 3px solid #FAFAFA;  /* creates padding around scroll thumb */
 }
+
+

--- a/frontend/src/actions/coursesActions.js
+++ b/frontend/src/actions/coursesActions.js
@@ -1,27 +1,27 @@
-export const appendCourse = (payload) => { 
-    return { 
-        type: 'APPEND', 
-        payload: payload
-    }
-}
+export const appendCourse = (payload) => {
+  return {
+    type: "APPEND",
+    payload: payload,
+  };
+};
 
-export const deleteCourse = (payload) => { 
-    return { 
-        type: 'DELETE', 
-        payload: payload, 
-    }
-}
+export const deleteCourse = (payload) => {
+  return {
+    type: "DELETE",
+    payload: payload,
+  };
+};
 
 export const setCourses = (payload) => {
-    return {
-        type: 'SET_COURSES',
-        payload: payload
-    }
-}
+  return {
+    type: "SET_COURSES",
+    payload: payload,
+  };
+};
 
 export const setCourse = (payload) => {
-    return {
-        type: 'SET_COURSE',
-        payload: payload
-    }
-}
+  return {
+    type: "SET_COURSE",
+    payload: payload,
+  };
+};

--- a/frontend/src/components/plannerCart/plannerCart.less
+++ b/frontend/src/components/plannerCart/plannerCart.less
@@ -21,7 +21,7 @@
 .planner-cart-content {
   padding: 5px;
   padding-left: 0px;
-  overflow-y: scroll;
+  overflow-y: auto;
   height: 70%;
   border-top: #f4f4f4 solid 1px;
 }

--- a/frontend/src/pages/CourseSelector/CourseTabs.jsx
+++ b/frontend/src/pages/CourseSelector/CourseTabs.jsx
@@ -1,43 +1,40 @@
-import React from 'react';
-import { Tabs } from 'antd';
-import { useSelector, useDispatch } from 'react-redux';
-import { courseTabActions } from '../../actions/courseTabActions';
-import './courseTabs.less';
+import React from "react";
+import { Tabs } from "antd";
+import { useSelector, useDispatch } from "react-redux";
+import { courseTabActions } from "../../actions/courseTabActions";
+import "./courseTabs.less";
 
 const { TabPane } = Tabs;
 export const CourseTabs = () => {
   const dispatch = useDispatch();
-  const { tabs, active } = useSelector(state => state.tabs);
+  const { tabs, active } = useSelector((state) => state.tabs);
   const handleChange = (activeKey) => {
     dispatch(courseTabActions("SET_ACTIVE_TAB", activeKey));
   };
 
   const handleEdit = (index, action) => {
-    if (action === 'add') { 
-      dispatch(courseTabActions('ADD_TAB', 'search'));
-    } else if (action === 'remove') {
-      dispatch(courseTabActions('REMOVE_TAB', index));
+    if (action === "add") {
+      dispatch(courseTabActions("ADD_TAB", "search"));
+    } else if (action === "remove") {
+      dispatch(courseTabActions("REMOVE_TAB", index));
     }
   };
 
   return (
-    <div className='cs-tabs-root'>
+    <div className="cs-tabs-root">
       {/* Placeholder div !!DO NOT DELETE */}
       <div></div>
       <Tabs
+        hideAdd
         type="editable-card"
         onChange={handleChange}
         activeKey={`${active}`}
         onEdit={handleEdit}
       >
         {tabs.map((tab, key) => (
-          <TabPane 
-            tab={tab} key={key} 
-            closable={!(tab === 'explore')}
-          />
+          <TabPane tab={tab} key={key} closable={!(tab === "explore")} />
         ))}
       </Tabs>
     </div>
   );
-
-}
+};

--- a/frontend/src/pages/CourseSelector/SearchCourse.jsx
+++ b/frontend/src/pages/CourseSelector/SearchCourse.jsx
@@ -101,8 +101,8 @@ export default function SearchCourse() {
 }
 
 const payload = {
-  program: "3778",
-  specialisations: { COMPA1: 1 },
+  program: "",
+  specialisations: {},
   courses: {},
   year: 0,
 };

--- a/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
+++ b/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
@@ -42,6 +42,7 @@ export default function CourseDescription() {
     }, 2000);
   }, [id]);
 
+  if (tabs.length === 0) return <div></div>;
   if (id === "explore") return <div>This is the explore page</div>;
   if (id === "search") return <SearchCourse />;
   const addToPlanner = () => {

--- a/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
+++ b/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
@@ -7,6 +7,7 @@ import { getCourseById } from "./../courseProvider";
 import SearchCourse from "../SearchCourse";
 import { plannerActions } from "../../../actions/plannerActions";
 import { Loading } from "./Loading";
+import { selectCourse } from "../../../actions/coursesActions";
 import "./courseDescription.less";
 
 const { Title, Text } = Typography;
@@ -43,7 +44,6 @@ export default function CourseDescription() {
 
   if (id === "explore") return <div>This is the explore page</div>;
   if (id === "search") return <SearchCourse />;
-
   const addToPlanner = () => {
     const data = {
       courseCode: course.code,
@@ -51,7 +51,7 @@ export default function CourseDescription() {
         title: course.title,
         type: "Uncategorised", // TODO: add type
         termsOffered: course.terms,
-        uoc: course.uoc,
+        UOC: course.UOC,
         plannedFor: null,
         warning: false,
         prereqs: "",

--- a/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.jsx
+++ b/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.jsx
@@ -23,16 +23,33 @@ export default function CourseMenu() {
     fetchStructure();
   }, []);
 
+  const { programCode, specialisation, minor } = useSelector(
+    (state) => state.degree
+  );
+  console.log(minor);
+
   // get structure of degree
   const fetchStructure = async () => {
     try {
       const res1 = await axios.get(
-        "http://localhost:8000/programs/getStructure/3778/COMPA1"
+        `http://localhost:8000/programs/getStructure/${programCode}/${specialisation}/${
+          minor !== "" && minor
+        }`
       );
       setStructure(res1.data.structure);
     } catch (err) {
       console.log(err);
     }
+  };
+
+  const { startYear } = useSelector((state) => state.planner);
+  const majors = {};
+  majors[specialisation] = 1;
+  const payload = {
+    program: programCode,
+    specialisations: majors,
+    courses: {},
+    year: new Date().getFullYear() - startYear,
   };
 
   // get all courses
@@ -125,11 +142,4 @@ const MenuItem = ({ courseCode }) => {
       {courseCode}
     </Menu.Item>
   );
-};
-
-const payload = {
-  program: "3778",
-  specialisations: { COMPA1: 1 },
-  courses: {},
-  year: 0,
 };

--- a/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.jsx
+++ b/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.jsx
@@ -14,6 +14,7 @@ export default function CourseMenu() {
   const [structure, setStructure] = React.useState({});
   const [menuData, setMenuData] = React.useState({});
   const [coursesUnits, setCoursesUnits] = React.useState({});
+  const [activeCourse, setActiveCourse] = React.useState("");
   const { active, tabs } = useSelector((state) => state.tabs);
   let id = tabs[active];
 
@@ -155,6 +156,8 @@ export default function CourseMenu() {
                       <MenuItem
                         selected={coursesInPlanner.get(courseCode)}
                         courseCode={courseCode}
+                        setActiveCourse={setActiveCourse}
+                        activeCourse={activeCourse}
                       />
                     ))}
                   </Menu.ItemGroup>
@@ -168,15 +171,17 @@ export default function CourseMenu() {
   );
 }
 
-const MenuItem = ({ selected, courseCode }) => {
+const MenuItem = ({ selected, courseCode, activeCourse, setActiveCourse }) => {
   const dispatch = useDispatch();
   const handleClick = () => {
     dispatch(courseTabActions("ADD_TAB", courseCode));
+    setActiveCourse(courseCode);
   };
 
   return (
     <Menu.Item
-      className={`text menuItemText ${selected !== undefined && "bold"}`}
+      className={`text menuItemText ${selected !== undefined && "bold"} 
+      ${activeCourse === courseCode && "activeCourse"}`}
       key={courseCode}
       onClick={handleClick}
     >

--- a/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.jsx
+++ b/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.jsx
@@ -52,11 +52,12 @@ export default function CourseMenu() {
   }
 
   const { startYear } = useSelector((state) => state.planner);
-  const majors = {};
-  majors[specialisation] = 1;
+  const specialisations = {};
+  specialisations[specialisation] = 1;
+  specialisations[minor] = 1;
   const payload = {
     program: programCode,
-    specialisations: majors,
+    specialisations: specialisations,
     courses: selectedCourses,
     year: new Date().getFullYear() - startYear,
   };
@@ -64,6 +65,7 @@ export default function CourseMenu() {
   // get all courses
   React.useEffect(async () => {
     try {
+      console.log(JSON.stringify(payload));
       const res = await axios.post(
         `http://localhost:8000/courses/getAllUnlocked/`,
         JSON.stringify(payload),

--- a/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.jsx
+++ b/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.jsx
@@ -34,7 +34,7 @@ export default function CourseMenu() {
     try {
       const res1 = await axios.get(
         `http://localhost:8000/programs/getStructure/${programCode}/${specialisation}/${
-          minor !== "" && minor
+          minor !== "" ? minor : ""
         }`
       );
       setStructure(res1.data.structure);
@@ -54,7 +54,7 @@ export default function CourseMenu() {
   const { startYear } = useSelector((state) => state.planner);
   const specialisations = {};
   specialisations[specialisation] = 1;
-  specialisations[minor] = 1;
+  if (minor !== "") specialisations[minor] = 1;
   const payload = {
     program: programCode,
     specialisations: specialisations,

--- a/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.less
+++ b/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.less
@@ -3,7 +3,8 @@
 .cs-menu-root {
   overflow: auto;
   overflow-x: hidden;
-  // height: 100%;
+  height: calc(100vh - 35vh);
+  scrollbar-width: thin; 
 }
 
 .subgroupContainer {
@@ -21,12 +22,18 @@
 }
 
 .menuItemText {
+  margin-left: 0px !important;
   font-size: small !important;
-  margin-left: 1.5em !important;
+  padding-left: 40px !important;
 }
 
 .bold {
-  font-weight: 600;
+  font-weight: 700;
+}
+
+.activeCourse {
+  color: #8044ca !important;
+  background-color: #EFDBFF;
 }
 
 .dark {
@@ -71,3 +78,6 @@
     border-right: 1px solid #F0F0F0;
   }
 }
+
+
+

--- a/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.less
+++ b/frontend/src/pages/CourseSelector/courseMenu/CourseMenu.less
@@ -2,7 +2,31 @@
 
 .cs-menu-root {
   overflow: auto;
+  overflow-x: hidden;
   // height: 100%;
+}
+
+.subgroupContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+
+.uocBadge {
+  border-radius: 1em;
+  background-color: #EFDBFF;
+  padding: 0.5em;
+  font-size: smaller;
+}
+
+.menuItemText {
+  font-size: small !important;
+  margin-left: 1.5em !important;
+}
+
+.bold {
+  font-weight: 600;
 }
 
 .dark {

--- a/frontend/src/pages/CourseSelector/courseTabs.less
+++ b/frontend/src/pages/CourseSelector/courseTabs.less
@@ -7,7 +7,7 @@
     display: grid;
     grid-template-columns: 20vw auto;
     padding-right: 30px;
-    padding-top: 10px;
+    padding-top: 15px;
     z-index: 100;
 }
 

--- a/frontend/src/pages/DegreeWizard/steps/DebouncingSelect.jsx
+++ b/frontend/src/pages/DegreeWizard/steps/DebouncingSelect.jsx
@@ -96,8 +96,8 @@ export default function DebouncingSelect({ setPlannedCourses }) {
 }
 
 const payload = {
-  program: "3778",
-  specialisations: { COMPA1: 1 },
+  program: "",
+  specialisations: {},
   courses: {},
   year: 0,
 };

--- a/frontend/src/pages/DegreeWizard/steps/PreviousCoursesStep.jsx
+++ b/frontend/src/pages/DegreeWizard/steps/PreviousCoursesStep.jsx
@@ -33,7 +33,7 @@ const TermBox = ({ yearIndex, termNo }) => {
             title: info.title,
             type: "Uncategorised", // TODO: add type
             termsOffered: info.terms,
-            uoc: info.uoc,
+            UOC: info.UOC,
             plannedFor: `${yearIndex + planner.startYear}${termNo}`,
             warning: false,
             prereqs: "",

--- a/frontend/src/reducers/courseTabsReducer.js
+++ b/frontend/src/reducers/courseTabsReducer.js
@@ -1,5 +1,5 @@
 const initial = {
-  tabs: ["explore"],
+  tabs: [],
   active: 0,
 };
 const courseTabsReducer = (state = initial, action) => {
@@ -29,15 +29,27 @@ const courseTabsReducer = (state = initial, action) => {
       };
     case "REMOVE_TAB":
       const index = action.payload;
+      console.log(index);
       let newTabs = [...state.tabs];
       newTabs.splice(index, 1);
+      console.log(newTabs.length);
+
       // If only one left, set active to 'explore'
       if (newTabs.length === 1) {
         return {
           tabs: newTabs,
           active: 0,
         };
+      }
+      // deleting tab before/equal to active tab
+      if (index <= state.active) {
+        console.log("yo");
+        return {
+          tabs: newTabs,
+          active: state.active - 1,
+        };
       } else {
+        // deleting tab after active tab
         return {
           ...state,
           tabs: newTabs,

--- a/frontend/src/reducers/courseTabsReducer.js
+++ b/frontend/src/reducers/courseTabsReducer.js
@@ -1,55 +1,55 @@
 const initial = {
-    tabs: ["explore"],
-    active: 0,
-}
-const courseTabsReducer = (state=initial, action) => { 
-    switch (action.type) { 
-        case "ADD_TAB":
-            const tabName = action.payload
-            // If tabName is search, add search and set active to new search 
-            if (tabName === 'search') {
-                return {
-                    tabs: [...state.tabs, "search"], 
-                    active: state.tabs.length
-                }
-            }
-            // If tabName is not search  && already exists 
-            const newActive = state.tabs.indexOf(tabName);
-            if (state.tabs.find(tab => tab === tabName)) {
-                return { 
-                    ...state,
-                    active: newActive
-                }
-            }
+  tabs: ["explore"],
+  active: 0,
+};
+const courseTabsReducer = (state = initial, action) => {
+  switch (action.type) {
+    case "ADD_TAB":
+      const tabName = action.payload;
+      // If tabName is search, add search and set active to new search
+      if (tabName === "search") {
+        return {
+          tabs: [...state.tabs, "search"],
+          active: state.tabs.length,
+        };
+      }
+      // If tabName is not search  && already exists
+      const newActive = state.tabs.indexOf(tabName);
+      if (state.tabs.find((tab) => tab === tabName)) {
+        return {
+          ...state,
+          active: newActive,
+        };
+      }
 
-            // Add new tab but don't change active
-            return {
-                tabs: [...state.tabs, tabName],
-                active: state.tabs.length,
-            }
-        case "REMOVE_TAB":
-            const index = action.payload;
-            let newTabs = [...state.tabs];
-            newTabs.splice(index, 1); 
-            // If only one left, set active to 'explore'
-            if (newTabs.length === 1) {
-                return {
-                    tabs: newTabs, 
-                    active: 0
-                }
-            } else {
-                return {
-                    ...state,
-                    tabs: newTabs
-                }
-            }
-        case "SET_ACTIVE_TAB": 
-            return {
-                ...state,
-                active: action.payload
-            }
-        default: 
-            return state;    
-    }
-}
-export default courseTabsReducer; 
+      // Add new tab but don't change active
+      return {
+        tabs: [...state.tabs, tabName],
+        active: state.tabs.length,
+      };
+    case "REMOVE_TAB":
+      const index = action.payload;
+      let newTabs = [...state.tabs];
+      newTabs.splice(index, 1);
+      // If only one left, set active to 'explore'
+      if (newTabs.length === 1) {
+        return {
+          tabs: newTabs,
+          active: 0,
+        };
+      } else {
+        return {
+          ...state,
+          tabs: newTabs,
+        };
+      }
+    case "SET_ACTIVE_TAB":
+      return {
+        ...state,
+        active: action.payload,
+      };
+    default:
+      return state;
+  }
+};
+export default courseTabsReducer;

--- a/frontend/src/reducers/courseTabsReducer.js
+++ b/frontend/src/reducers/courseTabsReducer.js
@@ -28,11 +28,11 @@ const courseTabsReducer = (state = initial, action) => {
         active: state.tabs.length,
       };
     case "REMOVE_TAB":
-      const index = action.payload;
-      console.log(index);
+      const index = parseInt(action.payload);
+      // console.log(index);
       let newTabs = [...state.tabs];
       newTabs.splice(index, 1);
-      console.log(newTabs.length);
+      // console.log(newTabs.length);
 
       // If only one left, set active to 'explore'
       if (newTabs.length === 1) {
@@ -41,18 +41,19 @@ const courseTabsReducer = (state = initial, action) => {
           active: 0,
         };
       }
-      // deleting tab before/equal to active tab
-      if (index <= state.active) {
-        console.log("yo");
-        return {
-          tabs: newTabs,
-          active: state.active - 1,
-        };
-      } else {
-        // deleting tab after active tab
+      const active = parseInt(state.active);
+
+      if (active === 0 || index > active) {
+        // deleting the very first tab or a tab after active tab
         return {
           ...state,
           tabs: newTabs,
+        };
+      } else {
+        // deleting tab before/equal to active tab
+        return {
+          tabs: newTabs,
+          active: active - 1,
         };
       }
     case "SET_ACTIVE_TAB":

--- a/frontend/src/reducers/coursesReducer.js
+++ b/frontend/src/reducers/coursesReducer.js
@@ -1,7 +1,6 @@
 const initialState = {
   courses: {},
   course: {},
-  selectedCourses: [],
 };
 const coursesReducer = (state = initialState, action) => {
   switch (action.type) {

--- a/frontend/src/reducers/coursesReducer.js
+++ b/frontend/src/reducers/coursesReducer.js
@@ -1,6 +1,7 @@
 const initialState = {
   courses: {},
   course: {},
+  selectedCourses: [],
 };
 const coursesReducer = (state = initialState, action) => {
   switch (action.type) {

--- a/frontend/src/reducers/degreeReducer.js
+++ b/frontend/src/reducers/degreeReducer.js
@@ -2,7 +2,7 @@ let initial = {
   programCode: "",
   programName: "",
   majors: [],
-  minor: [],
+  minor: "",
   specialisation: "",
 };
 

--- a/frontend/src/reducers/plannerReducer.js
+++ b/frontend/src/reducers/plannerReducer.js
@@ -46,7 +46,6 @@ const plannerReducer = (state = initialState, action) => {
       if (!state.courses[courseCode]) {
         newCourses.set(courseCode, courseData);
       }
-      console.log(newCourses.get(courseCode));
       // Append course code onto unplanned
       state.unplanned.push(courseCode);
       stateCopy = { ...state, courses: newCourses };

--- a/frontend/src/reducers/plannerReducer.js
+++ b/frontend/src/reducers/plannerReducer.js
@@ -31,6 +31,7 @@ let initialState = {
 };
 
 let stateCopy;
+let newCourses;
 
 const planner = JSON.parse(localStorage.getItem("planner"));
 if (planner) initialState = extractFromLocalStorage(planner);
@@ -41,12 +42,16 @@ const plannerReducer = (state = initialState, action) => {
     case "ADD_TO_UNPLANNED":
       const { courseCode, courseData } = action.payload;
       // Add course data to courses
+      newCourses = new Map(state.courses);
       if (!state.courses[courseCode]) {
-        state.courses.set(courseCode, courseData);
+        newCourses.set(courseCode, courseData);
       }
+      console.log(newCourses.get(courseCode));
       // Append course code onto unplanned
       state.unplanned.push(courseCode);
-      return state;
+      stateCopy = { ...state, courses: newCourses };
+      setInLocalStorage(stateCopy);
+      return stateCopy;
 
     case "ADD_TO_PLANNED":
       const { code, data, position } = action.payload;
@@ -57,7 +62,7 @@ const plannerReducer = (state = initialState, action) => {
 
       state.years[yearNum][termNum].push(code);
       // Add course data to courses
-
+      setInLocalStorage(state);
       return state;
 
     case "ADD_CORE_COURSES":
@@ -103,7 +108,7 @@ const plannerReducer = (state = initialState, action) => {
     case "REMOVE_COURSE":
       // Remove courses from years and courses
       const plannedTerm = state.courses.get(action.payload).plannedFor;
-      let newCourses = new Map(state.courses);
+      newCourses = new Map(state.courses);
       // console.log(newCourses.get(action.payload));
       newCourses.get(action.payload).plannedFor = null;
       newCourses.delete(action.payload);


### PR DESCRIPTION
- Course selector uses input saved from degree wizard
- Adding (and removing) course to term planner will add it to sidebar (bolded) and new unlocked courses will also appear
- Fixed deleting tab bug (where it wouldn't shift to the proper tab)
- Added UOC completed to the sidebar

Now, the backend team will find that testing `getAllUnlocked` will be easier with a working GUI. 
Also, each time a course is added (or removed) to term planner, I've console logged the request body for `getAllUnlocked`.  You might find this useful for debugging.