### PR TITLE
renamed frontend env variable to be recognised by react

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         echo "MONGODB_DATABASE=mongodb" >> env/backend.env
         echo "MONGO_INITDB_ROOT_USERNAME=github-ci" >> env/mongodb.env
         echo "MONGO_INITDB_ROOT_PASSWORD=github-ci" >> env/mongodb.env
-        echo "BACKEND_API_BASE_URL=http://localhost:8000/" >> env/frontend.env
+        echo "REACT_APP_BACKEND_API_BASE_URL=http://localhost:8000/" >> env/frontend.env
         docker compose run init-mongo
 
     - name: Test algorithm with pytest

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ In `mongodb.env`, add:
 - `MONGO_INITDB_ROOT_PASSWORD=...`
 
 In `frontend.env`, add:
-- `BACKEND_API_BASE_URL=http://localhost:8000/`
+- `REACT_APP_BACKEND_API_BASE_URL=http://localhost:8000/`
 
-> NOTE: The `BACKEND_API_BASE_URL` environment variable is the base url endpoint that the backend is running on. If the environment variable is not specified, the react application will default to using `http://localhost:8000/` as the base url when calling the API endpoint.
+> NOTE: The `REACT_APP_BACKEND_API_BASE_URL` environment variable is the base url endpoint that the backend is running on. If the environment variable is not specified, the react application will default to using `http://localhost:8000/` as the base url when calling the API endpoint.
 
 Replace the ellipses with a username and password. The username and password in `backend.env` must match the values in `mongodb.env`. The `env` folder has been added to `.gitignore` and will not be committed to the repo. 
 

--- a/frontend/src/axios.js
+++ b/frontend/src/axios.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
 // fallback to localhost port 8000 if env variable is not specified
-axios.defaults.baseURL = process.env.BACKEND_API_BASE_URL || 'http://localhost:8000/';
+axios.defaults.baseURL = process.env.REACT_APP_BACKEND_API_BASE_URL || 'http://localhost:8000/';
 
 axios.defaults.headers.post["Content-Type"] = "application/json";


### PR DESCRIPTION
Renamed `BACKEND_API_BASE_URL` env to `REACT_APP_BACKEND_API_BASE_URL` as react only recognises env vars starting with `REACT_APP_...`