### PR TITLE
Sano/fix 'mixed content' http error

### DIFF
--- a/frontend/src/components/Loading/Loading.jsx
+++ b/frontend/src/components/Loading/Loading.jsx
@@ -7,7 +7,6 @@ function Loading({ setLoading }) {
   const navigate = useNavigate();
 
   const location = useLocation();
-  console.log(location);
   // redirect index page to course selector
   let route = location.pathname === "/" ? "course-selector" : location.pathname;
 

--- a/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
+++ b/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
@@ -94,8 +94,10 @@ export default function CourseDescription({ structure }) {
 
   useEffect(() => {
     if (id === "explore" || id === "search") return;
-    dispatch(getCourseById(id));
-    getPathToCoursesById(id);
+    if (id) {
+      dispatch(getCourseById(id));
+      getPathToCoursesById(id);
+    }
     // turn off alert when moving to a different page
     setShow(false);
     setTimeout(() => {

--- a/frontend/src/pages/CourseSelector/main.jsx
+++ b/frontend/src/pages/CourseSelector/main.jsx
@@ -10,26 +10,26 @@ import SearchCourse from "./SearchCourse";
 export default function CourseSelector() {
   const [structure, setStructure] = React.useState({});
   const degree = useSelector((state) => state.degree);
-  
+
   const { programCode, programName, specialisation, minor } = useSelector(
     (state) => state.degree
   );
 
   React.useEffect(() => {
-    fetchStructure();
-  }, []);
-
-   // get structure of degree
-   const fetchStructure = async () => {
-    try {
-      const res1 = await axios.get(
-        `/programs/getStructure/${programCode}/${specialisation}/${minor}`
-      );
-      setStructure(res1.data.structure);
-    } catch (err) {
-      console.log(err);
-    }
-  };
+    // get structure of degree
+    const fetchStructure = async () => {
+      const endpoint = `/programs/getStructure/${programCode}/${specialisation}${
+        minor && `/${minor}`
+      }`;
+      try {
+        const res1 = await axios.get(endpoint);
+        setStructure(res1.data.structure);
+      } catch (err) {
+        console.log(err);
+      }
+    };
+    if (programCode && specialisation) fetchStructure();
+  }, [programCode, specialisation, minor]);
 
   return (
     <div className="cs-root">


### PR DESCRIPTION
If no minor is selected, we no longer attempt to fetch minor (which were producing trailing slashes at the end of the getStructure endpoint).
