### PR TITLE
CF-171 coursename collision with header

### DIFF
--- a/backend/server/routers/courses.py
+++ b/backend/server/routers/courses.py
@@ -307,7 +307,8 @@ def coursesUnlockedWhenTaken(userData: UserData, courseToBeTaken: str):
     return {
         'courses_unlocked_when_taken' : sorted(list(courses_now_unlocked - courses_initially_unlocked)),
         'direct_unlock': sorted(list(direct_unlock)),
-        'indirect_unlock': sorted(list(indirect_unlock))
+        'indirect_unlock': sorted(list(indirect_unlock)),
+        'test': 1
     }
 
 def unlocked_set(courses_state):

--- a/backend/server/routers/courses.py
+++ b/backend/server/routers/courses.py
@@ -297,18 +297,9 @@ def coursesUnlockedWhenTaken(userData: UserData, courseToBeTaken: str):
     user.add_courses({courseToBeTaken: [getCourse(courseToBeTaken)['UOC'], None]})
     ## final state
     courses_now_unlocked = unlocked_set(getAllUnlocked(user)['courses_state'])
-    new_courses = courses_now_unlocked - courses_initially_unlocked
-
-    ## Differentiate direct and indirect unlocks
-    path_to = set(getCourse(courseToBeTaken)['path_to'])
-    direct_unlock = new_courses.intersection(path_to)
-    indirect_unlock = new_courses - direct_unlock
 
     return {
         'courses_unlocked_when_taken' : sorted(list(courses_now_unlocked - courses_initially_unlocked)),
-        'direct_unlock': sorted(list(direct_unlock)),
-        'indirect_unlock': sorted(list(indirect_unlock)),
-        'test': 1
     }
 
 def unlocked_set(courses_state):

--- a/backend/server/routers/courses.py
+++ b/backend/server/routers/courses.py
@@ -297,8 +297,18 @@ def coursesUnlockedWhenTaken(userData: UserData, courseToBeTaken: str):
     user.add_courses({courseToBeTaken: [getCourse(courseToBeTaken)['UOC'], None]})
     ## final state
     courses_now_unlocked = unlocked_set(getAllUnlocked(user)['courses_state'])
+    new_courses = courses_now_unlocked - courses_initially_unlocked
 
-    return {'courses_unlocked_when_taken' : sorted(list(courses_now_unlocked - courses_initially_unlocked))}
+    ## Differentiate direct and indirect unlocks
+    path_to = set(getCourse(courseToBeTaken)['path_to'])
+    direct_unlock = new_courses.intersection(path_to)
+    indirect_unlock = new_courses - direct_unlock
+
+    return {
+        'courses_unlocked_when_taken' : sorted(list(courses_now_unlocked - courses_initially_unlocked)),
+        'direct_unlock': sorted(list(direct_unlock)),
+        'indirect_unlock': sorted(list(indirect_unlock))
+    }
 
 def unlocked_set(courses_state):
     """fetch the set of unlocked courses from the courses_state of a getAllUnlocked call"""

--- a/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
+++ b/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
@@ -98,6 +98,7 @@ export default function CourseDescription({ structure }) {
         `/courses/coursesUnlockedWhenTaken/${id}`,
         prepareUserPayload(degree, planner)
       );
+      console.log(data);
       if (!err) setCoursesPathTo(data.courses_unlocked_when_taken);
     };
 

--- a/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
+++ b/frontend/src/pages/CourseSelector/courseDescription/CourseDescription.jsx
@@ -98,7 +98,6 @@ export default function CourseDescription({ structure }) {
         `/courses/coursesUnlockedWhenTaken/${id}`,
         prepareUserPayload(degree, planner)
       );
-      console.log(data);
       if (!err) setCoursesPathTo(data.courses_unlocked_when_taken);
     };
 

--- a/frontend/src/pages/CourseSelector/main.less
+++ b/frontend/src/pages/CourseSelector/main.less
@@ -3,10 +3,12 @@
 .cs-root {
   margin: 0;
   padding: 0;
-  display: grid;
-  grid-template-rows: 20vh 55px 1fr;
-  // max-height: calc(100vh - 70px);
+  display: flex;
+  flex-direction: column;
+  // grid-template-rows: 20vh 55px 1fr;
+  max-height: calc(100vh - 70px);
 }
+
 
 .cs-top-cont {
   display: flex;
@@ -14,6 +16,12 @@
   justify-content: flex-end;
   padding: 1.7rem;
   position: relative;
+  height: 25vh;
+}
+@media (max-height: 800px) {
+  .cs-top-cont {
+    height: 200px;
+  }
 }
 
 .cs-degree-cont {


### PR DESCRIPTION
Fix coursename collision with header when height of window is reduced on `course selector` page.
Now using `vh` to set height of coursename element and a media query to fix a min height.