### PR TITLE
CF-154 reset tabs after resetting degree planner

### DIFF
--- a/frontend/src/actions/courseTabActions.js
+++ b/frontend/src/actions/courseTabActions.js
@@ -1,22 +1,25 @@
 export const courseTabActions = (action, payload) => {
-    switch (action) {
-        case 'ADD_TAB': 
-            return {
-                type: 'ADD_TAB', 
-                payload: payload
-            }
-        case 'REMOVE_TAB': 
-            return {
-                type: 'REMOVE_TAB', 
-                payload: payload
-            }
-        case 'SET_ACTIVE_TAB': 
-            return {
-                type: 'SET_ACTIVE_TAB',
-                payload: payload,
-            }
-        default: 
-            return null;
-    }
-} 
-
+  switch (action) {
+    case "ADD_TAB":
+      return {
+        type: "ADD_TAB",
+        payload: payload,
+      };
+    case "REMOVE_TAB":
+      return {
+        type: "REMOVE_TAB",
+        payload: payload,
+      };
+    case "SET_ACTIVE_TAB":
+      return {
+        type: "SET_ACTIVE_TAB",
+        payload: payload,
+      };
+    case "RESET_COURSE_TABS":
+      return {
+        type: "RESET_COURSE_TABS",
+      };
+    default:
+      return null;
+  }
+};

--- a/frontend/src/pages/DegreeWizard/main.jsx
+++ b/frontend/src/pages/DegreeWizard/main.jsx
@@ -7,16 +7,16 @@ import { PreviousCoursesStep } from "./steps/PreviousCoursesStep";
 import { MinorStep } from "./steps/MinorStep";
 import { plannerActions } from "../../actions/plannerActions";
 import { useDispatch } from "react-redux";
-import { useSpring, animated } from "react-spring";
-import { DatePicker, Button, Typography, Modal } from "antd";
+import { useSpring } from "react-spring";
+import { Button, Typography, Modal } from "antd";
 import "./main.less";
 import { springProps } from "./spring";
 import { scroller } from "react-scroll";
 import { useNavigate } from "react-router-dom";
 import { YearStep } from "./steps/YearStep";
+import { courseTabActions } from "../../actions/courseTabActions";
 
 const { Title } = Typography;
-const { RangePicker } = DatePicker;
 
 function DegreeWizard() {
   const theme = useSelector((store) => store.theme);
@@ -59,6 +59,7 @@ function DegreeWizard() {
     setIsModalVisible(false);
     // Degree selector needs to reset to prevent identical courses in a term
     dispatch(plannerActions("RESET_PLANNER"));
+    dispatch(courseTabActions("RESET_COURSE_TABS"));
   };
 
   const handleCancel = () => {

--- a/frontend/src/reducers/courseTabsReducer.js
+++ b/frontend/src/reducers/courseTabsReducer.js
@@ -61,6 +61,8 @@ const courseTabsReducer = (state = initial, action) => {
         ...state,
         active: action.payload,
       };
+    case "RESET_COURSE_TABS":
+      return initial;
     default:
       return state;
   }


### PR DESCRIPTION
Fix bug where course selector tabs would not be cleared when user resets the degree planner.