### PR TITLE
CF-164 added gap between course title and add to planner button

### DIFF
--- a/frontend/src/pages/CourseSelector/courseDescription/courseDescription.less
+++ b/frontend/src/pages/CourseSelector/courseDescription/courseDescription.less
@@ -26,6 +26,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  gap: 10px;
 }
 
 .cs-alert {


### PR DESCRIPTION
Title spacing now with gap
![image](https://user-images.githubusercontent.com/65492346/163814386-be20974a-74c0-4226-8629-20832370785c.png)
