### PR TITLE
Remove icon in search bar and fixed placeholder text when empty query

### DIFF
--- a/frontend/src/pages/CourseSelector/SearchCourse.jsx
+++ b/frontend/src/pages/CourseSelector/SearchCourse.jsx
@@ -50,7 +50,7 @@ const SearchCourse = () => {
   };
 
   const handleSearch = (courseCode) => {
-    setValue(courseCode);
+    setValue(courseCode || null);
     setCourses([]);
     setIsLoading(true);
   };
@@ -70,6 +70,7 @@ const SearchCourse = () => {
       onSelect={handleSelect}
       notFoundContent={isLoading && value && <Spin size="small" />}
       style={{ width: "30rem", marginRight: "0.5rem" }}
+      showArrow={!!value}
     />
   );
 };


### PR DESCRIPTION
Simple fix to remove the dropdown icon in search bar.

Before:
![image](https://user-images.githubusercontent.com/65492346/165736008-f615cff3-f2d5-4ff0-80c9-06c42ac043c4.png)

After:
![image](https://user-images.githubusercontent.com/65492346/165735938-92e4c8a0-da52-475b-b1ae-a5173b36db71.png)
