### PR TITLE
Chore/run app python3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,72 @@
-env
-*.env
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
 **/.pytest_cache
-**/.vscode
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Venv
+bin/**
+pyvenv.cfg
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
 **/.hypothesis
-**/.DS_Store
+.pytest_cache/
+cover/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Misc Log Files
 *.log
 *.out
 temp
 temp.*
 tmp
 tmp.*
+
+# Editor and OS files
+**/.vscode
+**/.DS_Store
 .idea
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,10 @@ To remove all containers and the docker network, run `docker-compose down`. Add 
 To stop a docker containers that is running, run `docker-compose stop <containerName>`. This will not remove the container.
 
 ### Running Circles without Docker
+
 It is now possible to run Circles without docker, and have your changes to the backend codebase be reflected in the development server. To do this, ensure nodemon is installed on your linux distribution by running `npm i -g nodemon`. Nodemon is a node package which automatically restarts an app when it detects code changes. 
 You can then run `python run_app.py` to run all of circles locally (assuming that you have installed all dependancies).
 Ensure your python3 version is set to 3.10. All parts of the app should now be running and talking to eachother. 
+
+If you have having trouble with `python not found`, manually choose what python version is being run by adding `PYTHON_VERSION=python3` or, any version of your choosing in `backend.env`.
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,4 @@ uvicorn==0.18.2
 zipp==3.8.0
 hypothesis==6.48.2
 more-itertools==8.13.0
+python-dotenv==0.20.0

--- a/run_app.py
+++ b/run_app.py
@@ -1,11 +1,13 @@
 # pylint: disable=cyclic-import
 """ run all of circles in one terminal """
 import logging
-from subprocess import Popen, check_call
-from dotenv import load_dotenv
-import threading
 import os
 import sys
+import threading
+from subprocess import Popen, check_call
+
+from dotenv import load_dotenv
+
 
 class LogPipe(threading.Thread):
     """ boilerplate abstraction for redirecting the logs of a process """

--- a/run_app.py
+++ b/run_app.py
@@ -2,6 +2,7 @@
 """ run all of circles in one terminal """
 import logging
 from subprocess import Popen, check_call
+from dotenv import load_dotenv
 import threading
 import os
 import sys
@@ -40,14 +41,15 @@ class LogPipe(threading.Thread):
 
 
 def get_backend_env():
-    """reads backend.env"""
-    with open('env/backend.env', encoding="utf8") as f:
-        data = f.readlines()
-    data[0] = data[0].replace('MONGODB_USERNAME=', '')
-    data[1] = data[1].replace('MONGODB_PASSWORD=', '')
-    data[0] = data[0].replace('\n', '')
-    data[1] = data[1].replace('\n', '')
-    return (data[0], data[1])
+    """
+        reads backend.env for mongodb username and password and python
+        version.
+    """
+    load_dotenv("./env/backend.env")
+    username = os.getenv("MONGODB_USERNAME")
+    password = os.getenv("MONGODB_USERNAME")
+    python = os.getenv("PYTHON_VERSION") or "python"
+    return (username, password, python)
 
 def main():
     logging.basicConfig(level=logging.INFO,format='%(asctime)s %(message)s',
@@ -58,11 +60,14 @@ def main():
     )
     sys.stdout = LogPipe(logging.INFO)
     sys.stderr = LogPipe(logging.ERROR)
-    username, password = get_backend_env()
+    print("ah")
+    username, password, python_ver = get_backend_env()
+    print("up", username,password, python_ver)
+    # sys.exit(0)
     os.system('docker compose run --rm init-mongo')
     try:
         Popen(
-            f'MONGODB_SERVICE_HOSTNAME=localhost MONGODB_PASSWORD={password} MONGODB_USERNAME={username}  nodemon --exec python runserver.py',
+            f'MONGODB_SERVICE_HOSTNAME=localhost MONGODB_PASSWORD={password} MONGODB_USERNAME={username}  nodemon --exec {python_ver} runserver.py',
             stdout=sys.stdout,
             stderr=sys.stderr,
             shell=True,

--- a/run_app.py
+++ b/run_app.py
@@ -60,10 +60,7 @@ def main():
     )
     sys.stdout = LogPipe(logging.INFO)
     sys.stderr = LogPipe(logging.ERROR)
-    print("ah")
     username, password, python_ver = get_backend_env()
-    print("up", username,password, python_ver)
-    # sys.exit(0)
     os.system('docker compose run --rm init-mongo')
     try:
         Popen(


### PR DESCRIPTION
- use load_env and os.getenv for getting backend env variables in `run_app` - now order of the env doesn't matter
- add `PYTHON_VERSION` as a viable envirionment variable (by default, `python`) to allow devs to specify what python version they want to use to run their app.
- Add clarification about python env variable to backend readme