### PR TITLE
feat(backend): Add gened courses support to getStructure endpoint

### DIFF
--- a/backend/data/scrapers/gened_scraper.py
+++ b/backend/data/scrapers/gened_scraper.py
@@ -62,9 +62,12 @@ def scrape_gened_data(year=None):
             )
         ), headers=HEADERS)
         new_gened_courses_raw = r.json()["contentlets"]
-  
+
         #gen eds by program code
-        gened_raw[program["code"]] = [course.get("code") for course in new_gened_courses_raw]
+        courses = {}
+        for course in new_gened_courses_raw:
+            courses[course["code"]] = course["title"]
+        gened_raw[program["code"]] = courses
     data_helpers.write_data(
         gened_raw,
         "data/scrapers/genedPureRaw.json"

--- a/backend/server/routers/courses.py
+++ b/backend/server/routers/courses.py
@@ -10,7 +10,7 @@ from data.utility.data_helpers import read_data
 from fastapi import APIRouter, HTTPException
 from fuzzywuzzy import fuzz
 from server.database import archivesDB, coursesCOL
-from server.routers.model import (CACHED_HANDBOOK_NOTE, CONDITIONS, Courses,
+from server.routers.model import (CACHED_HANDBOOK_NOTE, CONDITIONS, CourseCodes,
                                   CourseDetails, CoursesState, CoursesPath,
                                   CoursesUnlockedWhenTaken, ProgramCourses,
                                   UserData)
@@ -311,7 +311,7 @@ def get_legacy_course(year, courseCode):
     return result
 
 
-@router.post("/unselectCourse/{unselectedCourse}", response_model=Courses,
+@router.post("/unselectCourse/{unselectedCourse}", response_model=CourseCodes,
             responses={
                 400: {"description": "Uh oh you broke me"},
                 200: {

--- a/backend/server/routers/model.py
+++ b/backend/server/routers/model.py
@@ -103,7 +103,7 @@ class Courses(BaseModel):
     courses: list[str]
 
 class GenEdCourses(BaseModel):
-    courses: dict
+    courses: dict[str, str] = {}
 
 class CoursesPath (BaseModel):
     original: str

--- a/backend/server/routers/model.py
+++ b/backend/server/routers/model.py
@@ -98,14 +98,13 @@ class PlannerData(BaseModel):
     plan: list[list[dict]]
     mostRecentPastTerm: dict
 
-
-class Courses(BaseModel):
+class CourseCodes(BaseModel):
     courses: list[str]
 
-class GenEdCourses(BaseModel):
+class Courses(BaseModel):
     courses: dict[str, str] = {}
 
-class CoursesPath (BaseModel):
+class CoursesPath(BaseModel):
     original: str
     courses: list[str]
 

--- a/backend/server/routers/model.py
+++ b/backend/server/routers/model.py
@@ -99,9 +99,11 @@ class PlannerData(BaseModel):
     mostRecentPastTerm: dict
 
 
-class Courses (BaseModel):
+class Courses(BaseModel):
     courses: list[str]
 
+class GenEdCourses(BaseModel):
+    courses: dict
 
 class CoursesPath (BaseModel):
     original: str

--- a/backend/server/routers/programs.py
+++ b/backend/server/routers/programs.py
@@ -12,7 +12,7 @@ from server.routers.courses import regex_search
 from server.database import programsCOL, specialisationsCOL
 from server.routers.courses import regex_search
 from data.utility import data_helpers
-from server.routers.model import (Structure, Programs, GenEdCourses)
+from server.routers.model import (Structure, Programs, Courses)
 
 router = APIRouter(
     prefix="/programs",
@@ -237,7 +237,7 @@ def get_structure(
 
 @router.get(
     "/getGenEds/{programCode}",
-    response_model=GenEdCourses,
+    response_model=Courses,
     responses={
         400: {
             "description": "The given program code could not be found in the database",

--- a/backend/server/routers/programs.py
+++ b/backend/server/routers/programs.py
@@ -87,9 +87,7 @@ def add_subgroup_container(structure: dict, type: str, container: dict, exceptio
     item["courses"] = {}
     item["type"] = container.get("type") if container.get("type") is not None else ""
 
-    if container.get("courses") is None and container.get("type") == "gened":
-        item["courses"] = data_helpers.read_data("data/scrapers/genedPureRaw.json")
-    elif container.get("courses") is None:
+    if container.get("courses") is None:
         return []
 
     for object, description in container["courses"].items():
@@ -98,6 +96,20 @@ def add_subgroup_container(structure: dict, type: str, container: dict, exceptio
             in convert_subgroup_object_to_courses_dict(object, description).items()
             if course not in exceptions
         }
+
+    return list(item["courses"].keys())
+
+
+def add_geneds_courses(programCode: str, structure: dict, container: dict) -> list[str]:
+    """ Returns the added courses """
+    if container.get("type") != "gened":
+        return []
+
+    item = structure["General"]["General Education"]
+    item["courses"] = {}
+    
+    if container.get("courses") is None:
+        item["courses"] = data_helpers.read_data("data/scrapers/genedPureRaw.json").get(programCode)
 
     return list(item["courses"].keys())
 
@@ -214,6 +226,8 @@ def get_structure(
     with suppress(KeyError):
         for container in programsResult['components']['non_spec_data']:
             add_subgroup_container(structure, "General", container, [])
+            if container.get("type") == "gened":
+                add_geneds_courses(programCode, structure, container)
     apply_manual_fixes(structure, programCode)
 
     return {

--- a/backend/server/routers/programs.py
+++ b/backend/server/routers/programs.py
@@ -87,7 +87,9 @@ def add_subgroup_container(structure: dict, type: str, container: dict, exceptio
     item["courses"] = {}
     item["type"] = container.get("type") if container.get("type") is not None else ""
 
-    if container.get("courses") is None:
+    if container.get("courses") is None and container.get("type") == "gened":
+        item["courses"] = data_helpers.read_data("data/scrapers/genedPureRaw.json")
+    elif container.get("courses") is None:
         return []
 
     for object, description in container["courses"].items():

--- a/backend/server/routers/programs.py
+++ b/backend/server/routers/programs.py
@@ -12,7 +12,7 @@ from server.routers.courses import regex_search
 from server.database import programsCOL, specialisationsCOL
 from server.routers.courses import regex_search
 from data.utility import data_helpers
-from server.routers.model import (Structure, Programs, Courses)
+from server.routers.model import (Structure, Programs, GenEdCourses)
 
 router = APIRouter(
     prefix="/programs",
@@ -221,7 +221,7 @@ def get_structure(
 
 @router.get(
     "/getGenEds/{programCode}",
-    response_model=Courses,
+    response_model=GenEdCourses,
     responses={
         400: {
             "description": "The given program code could not be found in the database",
@@ -230,26 +230,20 @@ def get_structure(
             "description": "Returns all geneds available to a given to the given code",
             "content": {
                 "application/json": {
-                    "example": 
-                        {"courses": [
-                            "ADAD2610",
-                            "ANAT2521",
-                            "ARTS1010",
-                            "ARTS1011",
-                            "ARTS1030",
-                            "ARTS1031",
-                            "ARTS1032",
-                            "ARTS1060",
-                           
-                        ]
-                    
+                    "example": {
+                        "courses": {
+                            "ACTL3142": "Statistical Machine Learning for Risk and Actuarial Applications",
+                            "ACTL4305": "Actuarial Data Analytic Applications",
+                            "ADAD2610": "Art and Design for Environmental Challenges",
+                            "ANAT2521": "Biological Anthropology: Principles and Practices",
+                            "ARTS1010": "The Life of Words"
+                        }
                     }
                 }
             },
         },
     },
 )
-
 def getGenEds(
     programCode: str):
     all_geneds = data_helpers.read_data("data/scrapers/genedPureRaw.json")

--- a/backend/server/tests/test_validation.py
+++ b/backend/server/tests/test_validation.py
@@ -40,8 +40,10 @@ def assert_possible_structure(unlocked, program, spec):
     for container in structure:
         with suppress(KeyError):
             del structure[container]['name']
-            del structure[container]['Flexible Education']
+        with suppress(KeyError):
             del structure[container]['General Education']
+        with suppress(KeyError):
+            del structure[container]['Flexible Education']
 
         for container2 in structure[container]:
             with suppress(KeyError):

--- a/frontend/src/pages/CourseSelector/CourseSidebar/CourseSidebar.jsx
+++ b/frontend/src/pages/CourseSelector/CourseSidebar/CourseSidebar.jsx
@@ -57,11 +57,12 @@ const CourseSidebar = ({ structure, showLockedCourses }) => {
         };
         newMenu[group][subgroup] = [];
 
-        const isRule = subgroupStructure.type && subgroupStructure.type.includes("rule");
-
-        if (subgroupStructure.courses && !isRule) {
+        if (subgroupStructure.courses && !subgroupStructure.type.includes("rule")) {
           // only consider disciplinary component courses
           Object.keys(subgroupStructure.courses).forEach((courseCode) => {
+            // suppress gen ed courses if it has not been added to the planner
+            if (subgroupStructure.type === "gened" && !planner.courses[courseCode]) return;
+
             newMenu[group][subgroup].push({
               courseCode,
               title: subgroupStructure.courses[courseCode],

--- a/frontend/src/pages/GraphicalSelector/GraphicalSelector.jsx
+++ b/frontend/src/pages/GraphicalSelector/GraphicalSelector.jsx
@@ -82,7 +82,7 @@ const GraphicalSelector = () => {
     const courseList = (
       Object.values(structure)
         .flatMap((specialisation) => Object.values(specialisation)
-          .filter((spec) => typeof spec === "object" && spec.courses && !spec.type.includes("rule"))
+          .filter((spec) => typeof spec === "object" && spec.courses && !(spec.type.includes("rule") || spec.type.includes("gened")))
           .flatMap((spec) => Object.keys(spec.courses)))
         .filter((v, i, a) => a.indexOf(v) === i) // TODO: hack to make courseList unique
     );


### PR DESCRIPTION
FE wants to show gen ed courses on the progression checker, and the simple way to do this is to add the gen ed courses as part of the `getStructure` endpoint.

Changes made:
- Gen ed scrapper now returns course title alongside course code
- gen ed courses gets appended to the `getStructure` endpoint
- suppress gen eds from showing up on the course selector sidebar on the FE