### PR TITLE
feat(graphical-selector): Differentiate node style for planned courses

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,8 +39,8 @@
     "build": "vite build",
     "preview": "vite preview --host",
     "test": "jest",
-    "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
-    "lint:fix": "eslint --fix src/**/*.{js,jsx,ts,tsx}"
+    "lint": "eslint src/**/*.{js,jsx}",
+    "lint:fix": "eslint --fix src/**/*.{js,jsx}"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,8 @@
     "start": "vite --port 3000 --host",
     "build": "vite build",
     "preview": "vite preview --host",
-    "test": "jest",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage",
     "lint": "eslint src/**/*.{js,jsx}",
     "lint:fix": "eslint --fix src/**/*.{js,jsx}"
   },

--- a/frontend/src/components/PrerequisiteTree/config.js
+++ b/frontend/src/components/PrerequisiteTree/config.js
@@ -27,7 +27,7 @@ const defaultNode = {
   },
 };
 
-const prereqNodeAddtionalStyle = (courseName) => ({
+const prereqNodeAdditionalStyle = (courseName) => ({
   id: courseName,
   label: courseName,
   style: {
@@ -43,7 +43,7 @@ const prereqNodeAddtionalStyle = (courseName) => ({
   rootRelationship: TREE_CONSTANTS.PREREQ,
 });
 
-const unlocksNodeAddtionalStyle = (courseName) => ({
+const unlocksNodeAdditionalStyle = (courseName) => ({
   id: courseName,
   label: courseName,
   style: {
@@ -59,7 +59,7 @@ const unlocksNodeAddtionalStyle = (courseName) => ({
   rootRelationship: TREE_CONSTANTS.UNLOCKS,
 });
 
-const unrecognisedNodeAddtionalStyle = (courseName) => ({
+const unrecognisedNodeAdditionalStyle = (courseName) => ({
   id: courseName,
   label: courseName,
   rootRelationship: undefined,
@@ -104,9 +104,9 @@ const defaultEdgeAdditionalStyle = (id) => ({
 export default {
   graphLayout,
   defaultNode,
-  prereqNodeAddtionalStyle,
-  unlocksNodeAddtionalStyle,
-  unrecognisedNodeAddtionalStyle,
+  prereqNodeAdditionalStyle,
+  unlocksNodeAdditionalStyle,
+  unrecognisedNodeAdditionalStyle,
   defaultEdge,
   prereqEdgeAdditionalStyle,
   unlocksEdgeAdditionalStyle,

--- a/frontend/src/components/PrerequisiteTree/utils.js
+++ b/frontend/src/components/PrerequisiteTree/utils.js
@@ -4,11 +4,11 @@ import TREE_CONSTANTS from "./constants";
 const handleNodeData = (courseName, rootRelationship) => {
   switch (rootRelationship) {
     case TREE_CONSTANTS.PREREQ:
-      return GRAPH_STYLE.prereqNodeAddtionalStyle(courseName);
+      return GRAPH_STYLE.prereqNodeAdditionalStyle(courseName);
     case TREE_CONSTANTS.UNLOCKS:
-      return GRAPH_STYLE.unlocksNodeAddtionalStyle(courseName);
+      return GRAPH_STYLE.unlocksNodeAdditionalStyle(courseName);
     default:
-      return GRAPH_STYLE.unrecognisedNodeAddtionalStyle(courseName);
+      return GRAPH_STYLE.unrecognisedNodeAdditionalStyle(courseName);
   }
 };
 

--- a/frontend/src/pages/GraphicalSelector/GraphicalSelector.jsx
+++ b/frontend/src/pages/GraphicalSelector/GraphicalSelector.jsx
@@ -6,10 +6,13 @@ import axios from "axios";
 import PageTemplate from "components/PageTemplate";
 import Spinner from "components/Spinner";
 import axiosRequest from "config/axios";
+import GRAPH_STYLE from "./config";
 import S from "./styles";
+import handleNodeData from "./utils";
 
 const GraphicalSelector = () => {
   const { programCode, specs } = useSelector((state) => state.degree);
+  const { courses: plannedCourses } = useSelector((state) => state.planner);
 
   const [graph, setGraph] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -17,6 +20,7 @@ const GraphicalSelector = () => {
 
   const ref = useRef(null);
 
+  // courses is a list of course codes
   const initialiseGraph = (courses, courseEdges) => {
     const container = ref.current;
     const graphInstance = new G6.Graph({
@@ -38,28 +42,13 @@ const GraphicalSelector = () => {
         linkDistance: 500,
       },
       // animate: true,
-      defaultNode: {
-        size: 70,
-        style: {
-          fill: "#9254de",
-          stroke: "#9254de",
-          cursor: "pointer",
-        },
-        labelCfg: {
-          style: {
-            fill: "#fff",
-            fontFamily: "Segoe UI",
-            cursor: "pointer",
-          },
-        },
-
-      },
+      defaultNode: GRAPH_STYLE.defaultNode,
     });
 
     setGraph(graphInstance);
 
     const data = {
-      nodes: courses.map((c) => ({ id: c, label: c })),
+      nodes: courses.map((c) => handleNodeData(c, plannedCourses)),
       edges: courseEdges,
     };
 

--- a/frontend/src/pages/GraphicalSelector/config.js
+++ b/frontend/src/pages/GraphicalSelector/config.js
@@ -1,0 +1,34 @@
+const defaultNode = {
+  size: 70,
+  style: {
+    fill: "#9254de",
+    stroke: "#9254de",
+    cursor: "pointer",
+  },
+  labelCfg: {
+    style: {
+      fill: "#fff",
+      fontFamily: "Arial",
+      cursor: "pointer",
+    },
+  },
+};
+
+const unplannedNodeAdditionalStyle = (courseCode) => ({
+  id: courseCode,
+  label: courseCode,
+  style: {
+    fill: "#fff",
+    stroke: "#9254de",
+  },
+  labelCfg: {
+    style: {
+      fill: "#9254de",
+    },
+  },
+});
+
+export default {
+  defaultNode,
+  unplannedNodeAdditionalStyle,
+};

--- a/frontend/src/pages/GraphicalSelector/utils.js
+++ b/frontend/src/pages/GraphicalSelector/utils.js
@@ -3,7 +3,7 @@ import GRAPH_STYLE from "./config";
 // plannedCourses is an object of with keys of courseCodes
 const handleNodeData = (courseCode, plannedCourses) => {
   // determine if planned or unplanned
-  if (Object.prototype.hasOwnProperty.call(plannedCourses, courseCode)) {
+  if (plannedCourses[courseCode]) {
     // uses default node style
     return { id: courseCode, label: courseCode };
   }

--- a/frontend/src/pages/GraphicalSelector/utils.js
+++ b/frontend/src/pages/GraphicalSelector/utils.js
@@ -1,0 +1,13 @@
+import GRAPH_STYLE from "./config";
+
+// plannedCourses is an object of with keys of courseCodes
+const handleNodeData = (courseCode, plannedCourses) => {
+  // determine if planned or unplanned
+  if (Object.prototype.hasOwnProperty.call(plannedCourses, courseCode)) {
+    // uses default node style
+    return { id: courseCode, label: courseCode };
+  }
+  return GRAPH_STYLE.unplannedNodeAdditionalStyle(courseCode);
+};
+
+export default handleNodeData;


### PR DESCRIPTION
- config and utils for graphical selector
- determine whether course in planner or not an change colour based on it
- also was getting an error for linter script yesterday and today because it couldn't find ts and tsx scripts in the directory so removed them from the script


https://user-images.githubusercontent.com/90736577/180131777-371d2813-010d-4d55-a4b0-1231d8d61736.mov


