### PR TITLE
Adjust Height of Course Selector Banner

### DIFF
--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -2,7 +2,7 @@ body {
   --navbar-height: 70px;
   --option-header-height: 65px;
 
-  --cs-top-cont-height: 28%;
+  --cs-top-cont-height: 20%;
   --cs-tabs-cont-height: 40px;
   --cs-bottom-cont-height: calc(100% - var(--cs-top-cont-height) - var(--cs-tabs-cont-height));
 


### PR DESCRIPTION
Thought the Course Selector Banner was too big. This PR makes it less big by changing it from 28% to 20%.