### PR TITLE
chore(build): reduce bundle size

### DIFF
--- a/backend/server/routers/programs.py
+++ b/backend/server/routers/programs.py
@@ -346,7 +346,6 @@ def course_list_from_structure(structure: dict) -> list[str]:
             Recursively search for courses in a structure. Add
             courses found to `courses` object in upper group.
         """
-        print(structure.keys())
         if not isinstance(structure, (list, dict)):
             return
         for k, v in structure.items():

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,0 +1,2 @@
+vite.config.ts
+vitest.config.ts

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,15 +8,14 @@
       "name": "circles",
       "version": "0.1.0",
       "dependencies": {
-        "@ant-design/charts": "1.4.2",
         "@ant-design/colors": "6.0.0",
         "@ant-design/icons": "4.7.0",
+        "@ant-design/plots": "1.2.1",
         "@antv/algorithm": "0.1.24",
         "@antv/g6": "4.6.18",
         "@react-spring/web": "9.5.2",
         "@reduxjs/toolkit": "1.8.4",
         "@tippyjs/react": "4.2.6",
-        "@vitejs/plugin-react": "2.0.1",
         "antd": "4.22.5",
         "axios": "0.27.2",
         "framer-motion": "6.5.1",
@@ -37,9 +36,7 @@
         "redux-persist": "6.0.0",
         "redux-thunk": "2.4.1",
         "styled-components": "5.3.5",
-        "use-debounce": "8.0.3",
-        "vite": "3.0.8",
-        "vite-plugin-svgr": "2.2.1"
+        "use-debounce": "8.0.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "5.16.5",
@@ -51,6 +48,7 @@
         "@types/styled-components": "5.1.26",
         "@typescript-eslint/eslint-plugin": "5.33.1",
         "@typescript-eslint/parser": "5.33.1",
+        "@vitejs/plugin-react": "2.0.1",
         "eslint": "8.22.0",
         "eslint-config-airbnb": "19.0.4",
         "eslint-config-airbnb-typescript": "17.0.0",
@@ -62,8 +60,11 @@
         "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-simple-import-sort": "7.0.0",
         "less": "4.1.3",
+        "rollup-plugin-visualizer": "^5.7.1",
         "typescript": "4.7.4",
+        "vite": "3.0.8",
         "vite-plugin-eslint": "1.7.0",
+        "vite-plugin-svgr": "2.2.1",
         "vitest": "0.22.0"
       }
     },
@@ -73,12 +74,9 @@
       "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
       "dev": true
     },
-    "node_modules/@amap/amap-jsapi-loader": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
@@ -88,62 +86,11 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@ant-design/charts": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/charts/-/charts-1.4.2.tgz",
-      "integrity": "sha512-BcVx6AAnwxSdzAVUZReSuvUVtnT5AkJivq3wmcYj17scll26HHficg35yimGskAj3Gu1upYjBQBz6Tk7GEMJsQ==",
-      "dependencies": {
-        "@ant-design/flowchart": "^1.0.2",
-        "@ant-design/graphs": "^1.0.1",
-        "@ant-design/maps": "^1.0.1",
-        "@ant-design/plots": "^1.0.2"
-      },
-      "peerDependencies": {
-        "@ant-design/icons": "^4.6.0",
-        "antd": "^4.6.3",
-        "lodash": "^4.17.20",
-        "react": ">=16.8.4",
-        "react-dom": ">=16.8.4"
-      }
-    },
     "node_modules/@ant-design/colors": {
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@ctrl/tinycolor": "^3.4.0"
-      }
-    },
-    "node_modules/@ant-design/flowchart": {
-      "version": "1.1.8",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/layout": "^0.1.17",
-        "@antv/x6": "^1.25.0",
-        "@antv/x6-react-components": "^1.1.13",
-        "@antv/x6-react-shape": "^1.4.5",
-        "@antv/xflow": "^1.0.0",
-        "react-color": "2.17.3",
-        "react-use": "17.3.1"
-      },
-      "peerDependencies": {
-        "@ant-design/icons": "^4.6.0",
-        "antd": "^4.6.3",
-        "lodash": "^4.17.20",
-        "react": ">=16.8.4",
-        "react-dom": ">=16.8.4"
-      }
-    },
-    "node_modules/@ant-design/graphs": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/g6": "^4.2.4",
-        "@antv/util": "^2.0.9",
-        "react-content-loader": "^5.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.4",
-        "react-dom": ">=16.8.4"
       }
     },
     "node_modules/@ant-design/icons": {
@@ -168,22 +115,10 @@
       "version": "4.2.1",
       "license": "MIT"
     },
-    "node_modules/@ant-design/maps": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/l7plot": "~0.0.8",
-        "@antv/util": "^2.0.9",
-        "react-content-loader": "^5.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.4",
-        "react-dom": ">=16.8.4"
-      }
-    },
     "node_modules/@ant-design/plots": {
-      "version": "1.1.1",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/plots/-/plots-1.2.1.tgz",
+      "integrity": "sha512-wbcmhHRkVi7IFyqzVNUozcJtIpgWHOFHbny5T+DLQoE2lzh+A1nTOfhlPJXc6aq56uIg6w+4iN/umsJKUmcLPw==",
       "dependencies": {
         "@antv/g2plot": "^2.2.11",
         "react-content-loader": "^5.0.4"
@@ -226,13 +161,6 @@
       "dependencies": {
         "@antv/util": "^2.0.13",
         "tslib": "^2.0.0"
-      }
-    },
-    "node_modules/@antv/async-hook": {
-      "version": "2.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "async": "^3.1.1"
       }
     },
     "node_modules/@antv/attr": {
@@ -535,206 +463,6 @@
         "@antv/util": "^2.0.7"
       }
     },
-    "node_modules/@antv/l7": {
-      "version": "2.9.16",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/l7-component": "2.9.16",
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-layers": "2.9.16",
-        "@antv/l7-maps": "2.9.16",
-        "@antv/l7-scene": "2.9.16",
-        "@antv/l7-source": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7"
-      }
-    },
-    "node_modules/@antv/l7-component": {
-      "version": "2.9.16",
-      "license": "ISC",
-      "dependencies": {
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "eventemitter3": "^4.0.0",
-        "inversify": "^5.0.1",
-        "lodash": "^4.17.15",
-        "reflect-metadata": "^0.1.13",
-        "supercluster": "^7.0.0"
-      }
-    },
-    "node_modules/@antv/l7-core": {
-      "version": "2.9.16",
-      "license": "ISC",
-      "dependencies": {
-        "@antv/async-hook": "^2.1.0",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "ajv": "^6.10.2",
-        "element-resize-event": "^3.0.3",
-        "eventemitter3": "^4.0.0",
-        "gl-matrix": "^3.1.0",
-        "inversify": "^5.0.1",
-        "inversify-inject-decorators": "^3.1.0",
-        "l7-tiny-sdf": "^0.0.3",
-        "l7hammerjs": "^0.0.7",
-        "lodash": "^4.17.15",
-        "reflect-metadata": "^0.1.13",
-        "viewport-mercator-project": "^6.2.1"
-      }
-    },
-    "node_modules/@antv/l7-layers": {
-      "version": "2.9.16",
-      "license": "ISC",
-      "dependencies": {
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-source": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "@mapbox/martini": "^0.2.0",
-        "@turf/helpers": "^6.1.4",
-        "@turf/meta": "^6.0.2",
-        "@turf/union": "^6.5.0",
-        "d3-array": "1",
-        "d3-color": "^1.4.0",
-        "d3-interpolate": "1.4.0",
-        "d3-scale": "2",
-        "earcut": "^2.2.1",
-        "eventemitter3": "^4.0.0",
-        "extrude-polyline": "^1.0.6",
-        "gl-matrix": "^3.1.0",
-        "gl-vec2": "^1.3.0",
-        "inversify": "^5.0.1",
-        "lodash": "^4.17.15",
-        "merge-json-schemas": "1.0.0",
-        "polyline-miter-util": "^1.0.1",
-        "reflect-metadata": "^0.1.13"
-      }
-    },
-    "node_modules/@antv/l7-map": {
-      "version": "2.9.16",
-      "license": "ISC",
-      "dependencies": {
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "eventemitter3": "^4.0.4",
-        "lodash": "^4.17.15"
-      }
-    },
-    "node_modules/@antv/l7-maps": {
-      "version": "2.9.16",
-      "license": "ISC",
-      "dependencies": {
-        "@amap/amap-jsapi-loader": "^0.0.3",
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-map": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "@types/amap-js-api": "^1.4.6",
-        "@types/mapbox-gl": "^1.11.2",
-        "gl-matrix": "^3.1.0",
-        "inversify": "^5.0.1",
-        "mapbox-gl": "^1.2.1",
-        "reflect-metadata": "^0.1.13",
-        "viewport-mercator-project": "^6.2.1"
-      }
-    },
-    "node_modules/@antv/l7-renderer": {
-      "version": "2.9.16",
-      "license": "ISC",
-      "dependencies": {
-        "@antv/l7-core": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "inversify": "^5.0.1",
-        "l7regl": "^0.0.20",
-        "lodash": "^4.17.15",
-        "reflect-metadata": "^0.1.13"
-      }
-    },
-    "node_modules/@antv/l7-scene": {
-      "version": "2.9.16",
-      "license": "ISC",
-      "dependencies": {
-        "@antv/l7-component": "2.9.16",
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-layers": "2.9.16",
-        "@antv/l7-maps": "2.9.16",
-        "@antv/l7-renderer": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "inversify": "^5.0.1",
-        "mapbox-gl": "^1.2.1",
-        "reflect-metadata": "^0.1.13"
-      }
-    },
-    "node_modules/@antv/l7-source": {
-      "version": "2.9.16",
-      "license": "ISC",
-      "dependencies": {
-        "@antv/async-hook": "^2.1.0",
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "@mapbox/geojson-rewind": "^0.5.2",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@turf/helpers": "^6.1.4",
-        "@turf/invariant": "^6.1.2",
-        "@turf/meta": "^6.0.2",
-        "d3-dsv": "^1.1.1",
-        "d3-hexbin": "^0.2.2",
-        "eventemitter3": "^4.0.0",
-        "inversify": "^5.0.1",
-        "lodash": "^4.17.15",
-        "pbf": "^3.2.1",
-        "reflect-metadata": "^0.1.13",
-        "supercluster": "^7.0.0"
-      }
-    },
-    "node_modules/@antv/l7-utils": {
-      "version": "2.9.16",
-      "license": "ISC",
-      "dependencies": {
-        "@babel/runtime": "^7.7.7",
-        "@turf/bbox-polygon": "^6.5.0",
-        "@turf/helpers": "^6.1.4",
-        "d3-color": "^1.4.0"
-      }
-    },
-    "node_modules/@antv/l7plot": {
-      "version": "0.0.13",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/event-emitter": "^0.1.2",
-        "@antv/l7": "^2.9.14",
-        "@antv/l7plot-component": "^0.0.7",
-        "@antv/util": "^2.0.13",
-        "lodash-es": "^4.17.21",
-        "topojson-client": "^3.1.0"
-      },
-      "peerDependencies": {
-        "@antv/l7": "^2.9.14"
-      }
-    },
-    "node_modules/@antv/l7plot-component": {
-      "version": "0.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/dom-util": "^2.0.3",
-        "@antv/util": "^2.0.14"
-      }
-    },
-    "node_modules/@antv/layout": {
-      "version": "0.1.31",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/g-webgpu": "0.5.5",
-        "@dagrejs/graphlib": "2.1.4",
-        "d3-force": "^2.0.1",
-        "ml-matrix": "^6.5.0"
-      }
-    },
     "node_modules/@antv/matrix-util": {
       "version": "3.1.0-beta.3",
       "license": "ISC",
@@ -779,146 +507,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@antv/x6": {
-      "version": "1.32.8",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.3",
-        "jquery": "^3.5.1",
-        "jquery-mousewheel": "^3.1.13",
-        "lodash-es": "^4.17.15",
-        "mousetrap": "^1.6.5",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "node_modules/@antv/x6-react-components": {
-      "version": "1.1.15",
-      "license": "MIT",
-      "dependencies": {
-        "clamp": "^1.0.1",
-        "classnames": "^2.2.6",
-        "rc-dropdown": "^3.0.0-alpha.0",
-        "rc-util": "^4.15.7",
-        "react-color": "^2.17.3",
-        "react-resize-detector": "^6.6.4",
-        "ua-parser-js": "^0.7.20"
-      },
-      "peerDependencies": {
-        "antd": ">=4.4.2",
-        "react": ">=16.8.6 || >=17.0.0",
-        "react-dom": ">=16.8.6 || >=17.0.0"
-      }
-    },
-    "node_modules/@antv/x6-react-components/node_modules/rc-util": {
-      "version": "4.21.1",
-      "license": "MIT",
-      "dependencies": {
-        "add-dom-event-listener": "^1.1.0",
-        "prop-types": "^15.5.10",
-        "react-is": "^16.12.0",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "node_modules/@antv/x6-react-components/node_modules/react-is": {
-      "version": "16.13.1",
-      "license": "MIT"
-    },
-    "node_modules/@antv/x6-react-shape": {
-      "version": "1.6.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "@antv/x6": ">=1.0.0",
-        "react": ">=16.8.6 || >=17.0.0",
-        "react-dom": ">=16.8.6 || >=17.0.0"
-      }
-    },
-    "node_modules/@antv/xflow": {
-      "version": "1.0.49",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/layout": "^0.1.22",
-        "@antv/x6": "^1.30.1",
-        "@antv/x6-react-components": "^1.1.15",
-        "@antv/x6-react-shape": "^1.5.2",
-        "@antv/xflow-core": "1.0.49",
-        "@antv/xflow-extension": "1.0.49",
-        "@antv/xflow-hook": "1.0.49"
-      },
-      "peerDependencies": {
-        "@ant-design/icons": "^4.6.0",
-        "antd": "^4.6.3",
-        "lodash": "^4.17.20",
-        "react": "^16.8.0  || ^17.0.0",
-        "react-dom": "^16.8.0  || ^17.0.0"
-      }
-    },
-    "node_modules/@antv/xflow-core": {
-      "version": "1.0.49",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/xflow-hook": "1.0.49",
-        "classnames": "^2.3.1",
-        "immer": "^9.0.7",
-        "mana-common": "^0.3.1",
-        "mana-syringe": "^0.2.2",
-        "reflect-metadata": "^0.1.13",
-        "rxjs": "^6.6.7"
-      },
-      "peerDependencies": {
-        "@ant-design/icons": "^4.6.0",
-        "@antv/x6": "^1.30.1",
-        "@antv/x6-react-components": "^1.1.15",
-        "@antv/x6-react-shape": "^1.2.5",
-        "antd": "^4.6.3",
-        "lodash": "^4.17.20",
-        "react": "^16.8.0  || ^17.0.0",
-        "react-dom": "^16.8.0  || ^17.0.0"
-      }
-    },
-    "node_modules/@antv/xflow-extension": {
-      "version": "1.0.49",
-      "license": "MIT",
-      "dependencies": {
-        "@antv/xflow-core": "1.0.49",
-        "@antv/xflow-hook": "1.0.49",
-        "mana-syringe": "^0.2.2",
-        "moment": "^2.29.1",
-        "rc-field-form": "^1.22.0",
-        "react-color": "2.17.1",
-        "reflect-metadata": "^0.1.13"
-      },
-      "peerDependencies": {
-        "@ant-design/icons": "^4.6.0",
-        "@antv/x6": "^1.30.1",
-        "@antv/x6-react-components": "^1.1.15",
-        "@antv/x6-react-shape": "^1.2.5",
-        "antd": "^4.6.3",
-        "classnames": "^2.2.6",
-        "react": "^16.8.0  || ^17.0.0",
-        "react-dom": "^16.8.0  || ^17.0.0",
-        "reflect-metadata": "^0.1.13"
-      }
-    },
-    "node_modules/@antv/xflow-extension/node_modules/react-color": {
-      "version": "2.17.1",
-      "license": "MIT",
-      "dependencies": {
-        "@icons/material": "^0.2.4",
-        "lodash": "^4.17.11",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      }
-    },
-    "node_modules/@antv/xflow-hook": {
-      "version": "1.0.49",
-      "license": "MIT",
-      "dependencies": {
-        "toposort": "^2.0.2"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
       "license": "MIT",
@@ -931,6 +519,7 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.18.8",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -940,6 +529,7 @@
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
       "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -1002,6 +592,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.18.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.18.8",
@@ -1056,6 +647,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.18.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -1073,6 +665,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.18.9",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1080,6 +673,7 @@
     },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.18.6"
@@ -1115,6 +709,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1122,6 +717,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.18.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.18.6",
@@ -1214,6 +810,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -1229,6 +826,7 @@
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.18.10.tgz",
       "integrity": "sha512-gCy7Iikrpu3IZjYZolFE4M1Sm+nrh1/6za2Ewj77Z+XirT4TsbJcvOFOyF+fRPwU6AKKK136CZxx6L8AbSFG6A==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -1245,6 +843,7 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.18.6"
@@ -1258,6 +857,7 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -1271,6 +871,7 @@
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -1357,13 +958,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@dagrejs/graphlib": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.11.1"
-      }
-    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.8.8",
       "license": "MIT",
@@ -1446,13 +1040,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@icons/material": {
-      "version": "0.2.4",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@jest/schemas": {
       "version": "28.1.3",
       "dev": true,
@@ -1466,6 +1053,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
@@ -1499,64 +1087,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@mapbox/geojson-rewind": {
-      "version": "0.5.2",
-      "license": "ISC",
-      "dependencies": {
-        "get-stream": "^6.0.1",
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "geojson-rewind": "geojson-rewind"
-      }
-    },
-    "node_modules/@mapbox/geojson-types": {
-      "version": "1.0.2",
-      "license": "ISC"
-    },
-    "node_modules/@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "license": "BSD-3-Clause",
-      "peerDependencies": {
-        "mapbox-gl": ">=0.32.1 <2.0.0"
-      }
-    },
-    "node_modules/@mapbox/martini": {
-      "version": "0.2.0",
-      "license": "ISC"
-    },
-    "node_modules/@mapbox/point-geometry": {
-      "version": "0.1.0",
-      "license": "ISC"
-    },
-    "node_modules/@mapbox/tiny-sdf": {
-      "version": "1.2.5",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@mapbox/vector-tile": {
-      "version": "1.3.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@mapbox/point-geometry": "~0.1.0"
-      }
-    },
-    "node_modules/@mapbox/whoots-js": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@motionone/animation": {
@@ -1768,6 +1298,7 @@
     },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "estree-walker": "^2.0.1",
@@ -1786,6 +1317,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.3.1.tgz",
       "integrity": "sha512-jDBKArXYO1u0B1dmd2Nf8Oy6aTF5vLDfLoO9Oon/GLkqZ/NiggYWZA+a2HpUMH4ITwNqS3z43k8LWApB8S583w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1801,6 +1333,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.3.1.tgz",
       "integrity": "sha512-dQzyJ4prwjcFd929T43Z8vSYiTlTu8eafV40Z2gO7zy/SV5GT+ogxRJRBIKWomPBOiaVXFg3jY4S5hyEN3IBjQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1816,6 +1349,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.3.1.tgz",
       "integrity": "sha512-HBOUc1XwSU67fU26V5Sfb8MQsT0HvUyxru7d0oBJ4rA2s4HW3PhyAPC7fV/mdsSGpAvOdd8Wpvkjsr0fWPUO7A==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1831,6 +1365,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.3.1.tgz",
       "integrity": "sha512-C12e6aN4BXAolRrI601gPn5MDFCRHO7C4TM8Kks+rDtl8eEq+NN1sak0eAzJu363x3TmHXdZn7+Efd2nr9I5dA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1846,6 +1381,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.3.1.tgz",
       "integrity": "sha512-6NU55Mmh3M5u2CfCCt6TX29/pPneutrkJnnDCHbKZnjukZmmgUAZLtZ2g6ZoSPdarowaQmAiBRgAHqHmG0vuqA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1861,6 +1397,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.3.1.tgz",
       "integrity": "sha512-HV1NGHYTTe1vCNKlBgq/gKuCSfaRlKcHIADn7P8w8U3Zvujdw1rmusutghJ1pZJV7pDt3Gt8ws+SVrqHnBO/Qw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1876,6 +1413,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.3.1.tgz",
       "integrity": "sha512-2wZhSHvTolFNeKDAN/ZmIeSz2O9JSw72XD+o2bNp2QAaWqa8KGpn5Yk5WHso6xqfSAiRzAE+GXlsrBO4UP9LLw==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1891,6 +1429,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.3.1.tgz",
       "integrity": "sha512-cZ8Tr6ZAWNUFfDeCKn/pGi976iWSkS8ijmEYKosP+6ktdZ7lW9HVLHojyusPw3w0j8PI4VBeWAXAmi/2G7owxw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -1906,6 +1445,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-6.3.1.tgz",
       "integrity": "sha512-tQtWtzuMMQ3opH7je+MpwfuRA1Hf3cKdSgTtAYwOBDfmhabP7rcTfBi3E7V3MuwJNy/Y02/7/RutvwS1W4Qv9g==",
+      "dev": true,
       "dependencies": {
         "@svgr/babel-plugin-add-jsx-attribute": "^6.3.1",
         "@svgr/babel-plugin-remove-jsx-attribute": "^6.3.1",
@@ -1931,6 +1471,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.3.1.tgz",
       "integrity": "sha512-Sm3/7OdXbQreemf9aO25keerZSbnKMpGEfmH90EyYpj1e8wMD4TuwJIb3THDSgRMWk1kYJfSRulELBy4gVgZUA==",
+      "dev": true,
       "dependencies": {
         "@svgr/plugin-jsx": "^6.3.1",
         "camelcase": "^6.2.0",
@@ -1948,6 +1489,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-6.3.1.tgz",
       "integrity": "sha512-NgyCbiTQIwe3wHe/VWOUjyxmpUmsrBjdoIxKpXt3Nqc3TN30BpJG22OxBvVzsAh9jqep0w0/h8Ywvdk3D9niNQ==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.4",
         "entities": "^4.3.0"
@@ -1964,6 +1506,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-6.3.1.tgz",
       "integrity": "sha512-r9+0mYG3hD4nNtUgsTXWGYJomv/bNd7kC16zvsM70I/bGeoCi/3lhTmYqeN6ChWX317OtQCSZZbH4wq9WwoXbw==",
+      "dev": true,
       "dependencies": {
         "@babel/core": "^7.18.5",
         "@svgr/babel-preset": "^6.3.1",
@@ -2083,66 +1626,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@turf/bbox-polygon": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/helpers": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/invariant": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/meta": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/union": {
-      "version": "6.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "polygon-clipping": "^0.15.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@types/acorn": {
-      "version": "4.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
-    "node_modules/@types/amap-js-api": {
-      "version": "1.4.10",
-      "license": "MIT"
-    },
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
       "license": "MIT"
@@ -2176,10 +1659,7 @@
     },
     "node_modules/@types/estree": {
       "version": "0.0.41",
-      "license": "MIT"
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.10",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hoist-non-react-statics": {
@@ -2224,10 +1704,6 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
-    "node_modules/@types/js-cookie": {
-      "version": "2.2.7",
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "dev": true,
@@ -2238,13 +1714,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mapbox-gl": {
-      "version": "1.13.3",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "18.0.6",
       "dev": true,
@@ -2252,6 +1721,7 @@
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -2316,10 +1786,6 @@
       "dependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/resize-observer-browser": {
-      "version": "0.1.7",
-      "license": "MIT"
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
@@ -2588,6 +2054,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.0.1.tgz",
       "integrity": "sha512-uINzNHmjrbunlFtyVkST6lY1ewSfz/XwLufG0PIqvLGnpk2nOIOa/1CACTDNcKi1/RwaCzJLmsXwm1NsUVV/NA==",
+      "dev": true,
       "dependencies": {
         "@babel/core": "^7.18.10",
         "@babel/plugin-transform-react-jsx": "^7.18.10",
@@ -2612,10 +2079,6 @@
       "version": "0.0.31",
       "license": "Apache-2.0"
     },
-    "node_modules/@xobotyi/scrollbar-width": {
-      "version": "1.9.5",
-      "license": "MIT"
-    },
     "node_modules/acorn": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
@@ -2636,15 +2099,9 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/add-dom-event-listener": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "4.x"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2671,7 +2128,8 @@
     },
     "node_modules/amdefine": {
       "version": "1.0.1",
-      "license": "BSD-3-Clause OR MIT",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
       "engines": {
         "node": ">=0.4.2"
       }
@@ -2848,10 +2306,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/as-number": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "dev": true,
@@ -2864,10 +2318,6 @@
       "version": "0.0.7",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/async": {
-      "version": "3.2.4",
-      "license": "MIT"
     },
     "node_modules/async-validator": {
       "version": "4.2.5",
@@ -2959,6 +2409,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.21.2",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3006,6 +2457,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3013,6 +2465,7 @@
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3027,6 +2480,7 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001367",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3107,10 +2561,6 @@
         "node": "*"
       }
     },
-    "node_modules/clamp": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
     "node_modules/classnames": {
       "version": "2.3.1",
       "license": "MIT"
@@ -3186,10 +2636,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "license": "MIT"
-    },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.17",
       "license": "MIT"
@@ -3216,6 +2662,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.1"
@@ -3223,7 +2670,7 @@
     },
     "node_modules/copy-anything": {
       "version": "2.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-what": "^3.14.1"
@@ -3261,6 +2708,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -3300,14 +2748,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/css-in-js-utils": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
-    },
     "node_modules/css-line-break": {
       "version": "2.1.0",
       "license": "MIT",
@@ -3324,37 +2764,14 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
-    "node_modules/css-tree": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/csscolorparser": {
-      "version": "1.0.3",
-      "license": "MIT"
-    },
     "node_modules/csstype": {
       "version": "3.1.0",
       "license": "MIT"
-    },
-    "node_modules/d3-array": {
-      "version": "1.2.4",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-collection": {
-      "version": "1.0.7",
-      "license": "BSD-3-Clause"
     },
     "node_modules/d3-color": {
       "version": "1.4.1",
@@ -3363,26 +2780,6 @@
     "node_modules/d3-dispatch": {
       "version": "2.0.0",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-dsv": {
-      "version": "1.2.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "commander": "2",
-        "iconv-lite": "0.4",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json",
-        "csv2tsv": "bin/dsv2dsv",
-        "dsv2dsv": "bin/dsv2dsv",
-        "dsv2json": "bin/dsv2json",
-        "json2csv": "bin/json2dsv",
-        "json2dsv": "bin/json2dsv",
-        "json2tsv": "bin/json2dsv",
-        "tsv2csv": "bin/dsv2dsv",
-        "tsv2json": "bin/dsv2json"
-      }
     },
     "node_modules/d3-ease": {
       "version": "1.0.7",
@@ -3396,14 +2793,6 @@
         "d3-quadtree": "1 - 2",
         "d3-timer": "1 - 2"
       }
-    },
-    "node_modules/d3-format": {
-      "version": "1.4.5",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-hexbin": {
-      "version": "0.2.2",
-      "license": "BSD-3-Clause"
     },
     "node_modules/d3-hierarchy": {
       "version": "2.0.0",
@@ -3423,29 +2812,6 @@
     "node_modules/d3-regression": {
       "version": "1.3.10",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-scale": {
-      "version": "2.2.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-time-format": {
-      "version": "2.3.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-time": "1"
-      }
     },
     "node_modules/d3-timer": {
       "version": "1.0.10",
@@ -3544,6 +2910,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.4",
       "license": "MIT",
@@ -3627,17 +3002,10 @@
         "ignored": "bin/ignored"
       }
     },
-    "node_modules/earcut": {
-      "version": "2.2.4",
-      "license": "ISC"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.195",
+      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/element-resize-event": {
-      "version": "3.0.6",
-      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3648,6 +3016,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
       "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -3657,6 +3026,7 @@
     },
     "node_modules/errno": {
       "version": "0.1.8",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3668,6 +3038,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -3675,14 +3046,8 @@
     },
     "node_modules/error-ex/node_modules/is-arrayish": {
       "version": "0.2.1",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/error-stack-parser": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.3.4"
-      }
     },
     "node_modules/es-abstract": {
       "version": "1.20.1",
@@ -3744,6 +3109,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.14.49",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3780,6 +3146,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3791,6 +3158,7 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4388,6 +3756,7 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esutils": {
@@ -4402,38 +3771,9 @@
       "version": "4.0.7",
       "license": "MIT"
     },
-    "node_modules/extrude-polyline": {
-      "version": "1.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "as-number": "^1.0.0",
-        "gl-vec2": "^1.0.0",
-        "polyline-miter-util": "^1.0.1"
-      }
-    },
-    "node_modules/falafel": {
-      "version": "2.2.5",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "isarray": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/falafel/node_modules/acorn": {
-      "version": "7.4.1",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4466,18 +3806,12 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-shallow-equal": {
-      "version": "1.0.0"
-    },
-    "node_modules/fastest-stable-stringify": {
-      "version": "2.0.2",
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -4559,6 +3893,77 @@
         "uglify-js": "^2.6.2"
       }
     },
+    "node_modules/fmin/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fmin/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fmin/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fmin/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fmin/node_modules/rollup": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.25.8.tgz",
+      "integrity": "sha512-a2S4Bh3bgrdO4BhKr2E4nZkjTvrJ2m2bWjMTzVYtoqSCn0HnuxosXnaJUHrMEziOWr3CzL9GjilQQKcyCQpJoA==",
+      "dependencies": {
+        "chalk": "^1.1.1",
+        "minimist": "^1.2.0",
+        "source-map-support": "^0.3.2"
+      },
+      "bin": {
+        "rollup": "bin/rollup"
+      }
+    },
+    "node_modules/fmin/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fmin/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.1",
       "funding": [
@@ -4630,6 +4035,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -4673,14 +4079,20 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/geojson-vt": {
-      "version": "3.2.1",
-      "license": "ISC"
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/get-func-name": {
       "version": "2.0.0",
@@ -4700,16 +4112,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4792,6 +4194,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -4808,10 +4211,6 @@
       "dependencies": {
         "lodash": "^4.17.15"
       }
-    },
-    "node_modules/grid-index": {
-      "version": "1.1.0",
-      "license": "ISC"
     },
     "node_modules/hammerjs": {
       "version": "2.0.8",
@@ -4832,7 +4231,8 @@
     },
     "node_modules/has-ansi": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -4842,7 +4242,8 @@
     },
     "node_modules/has-ansi/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4927,38 +4328,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.0.4",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "dev": true,
@@ -4969,6 +4338,7 @@
     },
     "node_modules/image-size": {
       "version": "0.5.5",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -4988,6 +4358,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -5027,13 +4398,6 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
-    },
-    "node_modules/inline-style-prefixer": {
-      "version": "6.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "node_modules/insert-css": {
       "version": "2.0.0",
@@ -5144,12 +4508,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -5257,24 +4645,25 @@
     },
     "node_modules/is-what": {
       "version": "3.14.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "license": "MIT"
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/jest-diff": {
       "version": "28.1.3",
@@ -5362,17 +4751,6 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.6.0",
-      "license": "MIT"
-    },
-    "node_modules/jquery-mousewheel": {
-      "version": "3.1.13"
-    },
-    "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -5400,10 +4778,12 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -5430,6 +4810,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -5466,10 +4847,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/kdbush": {
-      "version": "3.0.0",
-      "license": "ISC"
-    },
     "node_modules/kind-of": {
       "version": "3.2.2",
       "license": "MIT",
@@ -5478,45 +4855,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/l7-tiny-sdf": {
-      "version": "0.0.3",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/l7eval5": {
-      "version": "0.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.4",
-        "@types/acorn": "^4.0.5",
-        "@types/estree": "0.0.41",
-        "acorn": "^7.1.0"
-      }
-    },
-    "node_modules/l7eval5/node_modules/acorn": {
-      "version": "7.4.1",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/l7hammerjs": {
-      "version": "0.0.7",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/l7regl": {
-      "version": "0.0.20",
-      "license": "MIT",
-      "dependencies": {
-        "falafel": "^2.2.4",
-        "l7eval5": "^0.0.3"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -5541,7 +4879,7 @@
     },
     "node_modules/less": {
       "version": "4.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "copy-anything": "^2.0.1",
@@ -5578,6 +4916,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/local-pkg": {
@@ -5607,37 +4946,13 @@
       "version": "4.17.21",
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isarray": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isnil": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.mergewith": {
-      "version": "4.6.2",
-      "license": "MIT"
-    },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
-      "license": "MIT"
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
       "license": "MIT"
     },
     "node_modules/longest": {
@@ -5688,6 +5003,7 @@
       "version": "0.26.2",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
       "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+      "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       },
@@ -5697,6 +5013,7 @@
     },
     "node_modules/make-dir": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5709,78 +5026,16 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "5.7.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
-    "node_modules/mana-common": {
-      "version": "0.3.1"
-    },
-    "node_modules/mana-syringe": {
-      "version": "0.2.2",
-      "dependencies": {
-        "inversify": "^5.0.1"
-      }
-    },
-    "node_modules/mapbox-gl": {
-      "version": "1.13.2",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.0",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.1",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.2",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.2.1",
-        "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^7.1.0",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6.4.0"
-      }
-    },
-    "node_modules/material-colors": {
-      "version": "1.2.6",
-      "license": "ISC"
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.14",
-      "license": "CC0-1.0"
-    },
     "node_modules/memoize-one": {
       "version": "6.0.0",
       "license": "MIT"
-    },
-    "node_modules/merge-json-schemas": {
-      "version": "1.0.0",
-      "license": "Private",
-      "dependencies": {
-        "lodash.isarray": "^4.0.0",
-        "lodash.isnil": "^4.0.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.mergewith": "^4.6.0",
-        "lodash.uniq": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5806,6 +5061,7 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -5892,38 +5148,13 @@
         "node": "*"
       }
     },
-    "node_modules/mousetrap": {
-      "version": "1.6.5",
-      "license": "Apache-2.0 WITH LLVM-exception"
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
     },
-    "node_modules/murmurhash-js": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/nano-css": {
-      "version": "5.3.5",
-      "license": "Unlicense",
-      "dependencies": {
-        "css-tree": "^1.1.2",
-        "csstype": "^3.0.6",
-        "fastest-stable-stringify": "^2.0.2",
-        "inline-style-prefixer": "^6.0.0",
-        "rtl-css-js": "^1.14.0",
-        "sourcemap-codec": "^1.4.8",
-        "stacktrace-js": "^2.0.2",
-        "stylis": "^4.0.6"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -5939,6 +5170,7 @@
     },
     "node_modules/needle": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5955,6 +5187,7 @@
     },
     "node_modules/needle/node_modules/debug": {
       "version": "3.2.7",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5963,6 +5196,7 @@
     },
     "node_modules/needle/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5974,6 +5208,7 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -6091,6 +5326,23 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "dev": true,
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "dev": true,
@@ -6139,6 +5391,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -6149,6 +5402,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -6165,7 +5419,7 @@
     },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -6200,6 +5454,7 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6213,17 +5468,6 @@
         "node": "*"
       }
     },
-    "node_modules/pbf": {
-      "version": "3.2.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ieee754": "^1.1.12",
-        "resolve-protobuf-schema": "^2.1.0"
-      },
-      "bin": {
-        "pbf": "bin/pbf"
-      }
-    },
     "node_modules/pdfast": {
       "version": "0.2.0",
       "license": "MIT"
@@ -6235,6 +5479,7 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6249,17 +5494,11 @@
     },
     "node_modules/pify": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/polygon-clipping": {
-      "version": "0.15.3",
-      "license": "MIT",
-      "dependencies": {
-        "splaytree": "^3.1.0"
       }
     },
     "node_modules/polyline-miter-util": {
@@ -6290,6 +5529,7 @@
       "version": "8.4.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
       "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6312,10 +5552,6 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "license": "MIT"
-    },
-    "node_modules/potpack": {
-      "version": "1.0.2",
-      "license": "ISC"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -6374,17 +5610,15 @@
       "version": "16.13.1",
       "license": "MIT"
     },
-    "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "license": "MIT"
-    },
     "node_modules/prr": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/punycode": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6409,10 +5643,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/quickselect": {
-      "version": "2.0.0",
-      "license": "ISC"
     },
     "node_modules/raf": {
       "version": "3.4.1",
@@ -6512,20 +5742,6 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-dropdown": {
-      "version": "3.6.2",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.17.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.11.0",
-        "react-dom": ">=16.11.0"
       }
     },
     "node_modules/rc-field-form": {
@@ -7054,18 +6270,6 @@
         }
       }
     },
-    "node_modules/react-color": {
-      "version": "2.17.3",
-      "license": "MIT",
-      "dependencies": {
-        "@icons/material": "^0.2.4",
-        "lodash": "^4.17.11",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      }
-    },
     "node_modules/react-component-export-image": {
       "version": "1.0.6",
       "license": "MIT",
@@ -7138,10 +6342,6 @@
       "version": "18.2.0",
       "license": "MIT"
     },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "license": "MIT"
-    },
     "node_modules/react-redux": {
       "version": "8.0.2",
       "license": "MIT",
@@ -7183,21 +6383,9 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-resize-detector": {
-      "version": "6.7.8",
-      "license": "MIT",
-      "dependencies": {
-        "@types/resize-observer-browser": "^0.1.6",
-        "lodash": "^4.17.21",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/react-router": {
@@ -7269,44 +6457,6 @@
       "peerDependencies": {
         "react": ">=16.0.0",
         "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/react-universal-interface": {
-      "version": "0.6.2",
-      "peerDependencies": {
-        "react": "*",
-        "tslib": "*"
-      }
-    },
-    "node_modules/react-use": {
-      "version": "17.3.1",
-      "license": "Unlicense",
-      "dependencies": {
-        "@types/js-cookie": "^2.2.6",
-        "@xobotyi/scrollbar-width": "^1.9.5",
-        "copy-to-clipboard": "^3.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-shallow-equal": "^1.0.0",
-        "js-cookie": "^2.2.1",
-        "nano-css": "^5.3.1",
-        "react-universal-interface": "^0.6.2",
-        "resize-observer-polyfill": "^1.5.1",
-        "screenfull": "^5.1.0",
-        "set-harmonic-interval": "^1.0.1",
-        "throttle-debounce": "^3.0.1",
-        "ts-easing": "^0.2.0",
-        "tslib": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0  || ^17.0.0",
-        "react-dom": "^16.8.0  || ^17.0.0"
-      }
-    },
-    "node_modules/reactcss": {
-      "version": "1.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.0.1"
       }
     },
     "node_modules/redent": {
@@ -7387,6 +6537,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "4.1.6",
       "license": "MIT"
@@ -7412,16 +6571,10 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/resolve-protobuf-schema": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/resumer": {
@@ -7474,74 +6627,77 @@
       }
     },
     "node_modules/rollup": {
-      "version": "0.25.8",
-      "license": "MIT",
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.0.tgz",
+      "integrity": "sha512-4+YfbQC9QEVvKTanHhIAFVUFSRsezvQF8vFOJwtGfb9Bb+r014S+qryr9PSmw8x6sMnPkmFBGAvIFVQxvJxjtg==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.7.1.tgz",
+      "integrity": "sha512-E/IgOMnmXKlc6ICyf53ok1b6DxPeNVUs3R0kYYPuDpGfofT4bkiG+KtSMlGjMACFmfwbbqTVDZBIF7sMZVKJbA==",
+      "dev": true,
       "dependencies": {
-        "chalk": "^1.1.1",
-        "minimist": "^1.2.0",
-        "source-map-support": "^0.3.2"
+        "nanoid": "^3.3.4",
+        "open": "^8.4.0",
+        "source-map": "^0.7.3",
+        "yargs": "^17.5.1"
       },
       "bin": {
-        "rollup": "bin/rollup"
-      }
-    },
-    "node_modules/rollup/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rollup/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rollup/node_modules/chalk": {
-      "version": "1.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0"
       }
     },
-    "node_modules/rollup/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/rollup/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "license": "MIT",
+    "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": "^2.0.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rollup/node_modules/supports-color": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/rtl-css-js": {
-      "version": "1.15.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2"
+        "node": ">=12"
       }
     },
     "node_modules/run-parallel": {
@@ -7571,30 +6727,20 @@
       "version": "1.3.3",
       "license": "BSD-3-Clause"
     },
-    "node_modules/rxjs": {
-      "version": "6.6.7",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
-    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/sax": {
       "version": "1.2.4",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -7606,16 +6752,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "node_modules/screenfull": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/scroll-into-view-if-needed": {
       "version": "2.2.29",
       "license": "MIT",
@@ -7625,16 +6761,10 @@
     },
     "node_modules/semver": {
       "version": "6.3.0",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/set-harmonic-interval": {
-      "version": "1.0.1",
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=6.9"
       }
     },
     "node_modules/shallowequal": {
@@ -7695,13 +6825,16 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
+      "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7709,13 +6842,16 @@
     },
     "node_modules/source-map-support": {
       "version": "0.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
+      "integrity": "sha512-9O4+y9n64RewmFoKUZ/5Tx9IHIcXM6Q+RTSw6ehnqybUz4a7iwR3Eaw80uLtqqQ5D0C+5H03D4KKGo9PdP33Gg==",
       "dependencies": {
         "source-map": "0.1.32"
       }
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+      "integrity": "sha512-htQyLrrRLkQ87Zfrir4/yN+vAUd6DNjVayEjTSHXu29AYQJw57I4/xEL/M6p6E/woPNJwvZt6rVlzc7gFEJccQ==",
       "dependencies": {
         "amdefine": ">=0.0.4"
       },
@@ -7725,18 +6861,8 @@
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/splaytree": {
-      "version": "3.1.1",
-      "license": "MIT"
-    },
-    "node_modules/stack-generator": {
-      "version": "2.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.3.4"
-      }
     },
     "node_modules/stackblur-canvas": {
       "version": "2.5.0",
@@ -7746,37 +6872,29 @@
         "node": ">=0.1.14"
       }
     },
-    "node_modules/stackframe": {
-      "version": "1.3.4",
-      "license": "MIT"
-    },
-    "node_modules/stacktrace-gps": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "0.5.6",
-        "stackframe": "^1.3.4"
-      }
-    },
-    "node_modules/stacktrace-gps/node_modules/source-map": {
-      "version": "0.5.6",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stacktrace-js": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "error-stack-parser": "^2.0.6",
-        "stack-generator": "^2.0.5",
-        "stacktrace-gps": "^3.0.4"
-      }
-    },
     "node_modules/string-convert": {
       "version": "0.2.1",
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.7",
@@ -7937,17 +7055,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.1.1",
-      "license": "MIT"
-    },
-    "node_modules/supercluster": {
-      "version": "7.1.5",
-      "license": "ISC",
-      "dependencies": {
-        "kdbush": "^3.0.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "license": "MIT",
@@ -7971,7 +7078,8 @@
     "node_modules/svg-parser": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
-      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
+      "dev": true
     },
     "node_modules/svg-pathdata": {
       "version": "6.0.3",
@@ -8017,13 +7125,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/throttle-debounce": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "license": "MIT"
@@ -8046,10 +7147,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/tinyqueue": {
-      "version": "2.0.3",
-      "license": "ISC"
     },
     "node_modules/tinyspy": {
       "version": "1.0.0",
@@ -8089,26 +7186,6 @@
     "node_modules/toggle-selection": {
       "version": "1.0.6",
       "license": "MIT"
-    },
-    "node_modules/topojson-client": {
-      "version": "3.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "commander": "2"
-      },
-      "bin": {
-        "topo2geo": "bin/topo2geo",
-        "topomerge": "bin/topomerge",
-        "topoquantize": "bin/topoquantize"
-      }
-    },
-    "node_modules/toposort": {
-      "version": "2.0.2",
-      "license": "MIT"
-    },
-    "node_modules/ts-easing": {
-      "version": "0.2.0",
-      "license": "Unlicense"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -8200,23 +7277,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "0.7.31",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/uglify-js": {
       "version": "2.8.29",
       "license": "BSD-2-Clause",
@@ -8261,6 +7321,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.5",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8285,6 +7346,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -8315,13 +7377,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/utility-types": {
-      "version": "3.10.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/utrie": {
       "version": "1.0.2",
       "license": "MIT",
@@ -8341,18 +7396,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/viewport-mercator-project": {
-      "version": "6.2.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "gl-matrix": "^3.0.0"
-      }
-    },
     "node_modules/vite": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.8.tgz",
       "integrity": "sha512-AOZ4eN7mrkJiOLuw8IA7piS4IdOQyQCA81GxGsAQvAZzMRi9ZwGB3TOaYsj4uLAWK46T5L4AfQ6InNGlxX30IQ==",
+      "dev": true,
       "dependencies": {
         "esbuild": "^0.14.47",
         "postcss": "^8.4.16",
@@ -8403,24 +7451,11 @@
         "vite": ">=2"
       }
     },
-    "node_modules/vite-plugin-eslint/node_modules/rollup": {
-      "version": "2.77.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/vite-plugin-svgr": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-2.2.1.tgz",
       "integrity": "sha512-+EqwahbwjETJH/ssA/66dNYyKN1cO0AStq96MuXmq5maU7AePBMf2lDKfQna49tJZAjtRz+R899BWCsUUP45Fg==",
+      "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
         "@svgr/core": "^6.3.1"
@@ -8433,6 +7468,7 @@
       "version": "2.77.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
       "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+      "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -8493,15 +7529,6 @@
         }
       }
     },
-    "node_modules/vt-pbf": {
-      "version": "3.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.2.1"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -8551,9 +7578,35 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -8563,6 +7616,7 @@
     },
     "node_modules/yaml": {
       "version": "1.10.2",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -8576,6 +7630,15 @@
         "cliui": "^2.1.0",
         "decamelize": "^1.0.0",
         "window-size": "0.1.0"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/camelcase": {
@@ -8605,51 +7668,18 @@
       "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==",
       "dev": true
     },
-    "@amap/amap-jsapi-loader": {
-      "version": "0.0.3"
-    },
     "@ampproject/remapping": {
       "version": "2.2.0",
+      "dev": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
-    "@ant-design/charts": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/charts/-/charts-1.4.2.tgz",
-      "integrity": "sha512-BcVx6AAnwxSdzAVUZReSuvUVtnT5AkJivq3wmcYj17scll26HHficg35yimGskAj3Gu1upYjBQBz6Tk7GEMJsQ==",
-      "requires": {
-        "@ant-design/flowchart": "^1.0.2",
-        "@ant-design/graphs": "^1.0.1",
-        "@ant-design/maps": "^1.0.1",
-        "@ant-design/plots": "^1.0.2"
       }
     },
     "@ant-design/colors": {
       "version": "6.0.0",
       "requires": {
         "@ctrl/tinycolor": "^3.4.0"
-      }
-    },
-    "@ant-design/flowchart": {
-      "version": "1.1.8",
-      "requires": {
-        "@antv/layout": "^0.1.17",
-        "@antv/x6": "^1.25.0",
-        "@antv/x6-react-components": "^1.1.13",
-        "@antv/x6-react-shape": "^1.4.5",
-        "@antv/xflow": "^1.0.0",
-        "react-color": "2.17.3",
-        "react-use": "17.3.1"
-      }
-    },
-    "@ant-design/graphs": {
-      "version": "1.2.1",
-      "requires": {
-        "@antv/g6": "^4.2.4",
-        "@antv/util": "^2.0.9",
-        "react-content-loader": "^5.0.4"
       }
     },
     "@ant-design/icons": {
@@ -8665,16 +7695,10 @@
     "@ant-design/icons-svg": {
       "version": "4.2.1"
     },
-    "@ant-design/maps": {
-      "version": "1.0.3",
-      "requires": {
-        "@antv/l7plot": "~0.0.8",
-        "@antv/util": "^2.0.9",
-        "react-content-loader": "^5.0.4"
-      }
-    },
     "@ant-design/plots": {
-      "version": "1.1.1",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/plots/-/plots-1.2.1.tgz",
+      "integrity": "sha512-wbcmhHRkVi7IFyqzVNUozcJtIpgWHOFHbny5T+DLQoE2lzh+A1nTOfhlPJXc6aq56uIg6w+4iN/umsJKUmcLPw==",
       "requires": {
         "@antv/g2plot": "^2.2.11",
         "react-content-loader": "^5.0.4"
@@ -8709,12 +7733,6 @@
       "requires": {
         "@antv/util": "^2.0.13",
         "tslib": "^2.0.0"
-      }
-    },
-    "@antv/async-hook": {
-      "version": "2.1.0",
-      "requires": {
-        "async": "^3.1.1"
       }
     },
     "@antv/attr": {
@@ -9005,190 +8023,6 @@
         "@antv/util": "^2.0.7"
       }
     },
-    "@antv/l7": {
-      "version": "2.9.16",
-      "requires": {
-        "@antv/l7-component": "2.9.16",
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-layers": "2.9.16",
-        "@antv/l7-maps": "2.9.16",
-        "@antv/l7-scene": "2.9.16",
-        "@antv/l7-source": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7"
-      }
-    },
-    "@antv/l7-component": {
-      "version": "2.9.16",
-      "requires": {
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "eventemitter3": "^4.0.0",
-        "inversify": "^5.0.1",
-        "lodash": "^4.17.15",
-        "reflect-metadata": "^0.1.13",
-        "supercluster": "^7.0.0"
-      }
-    },
-    "@antv/l7-core": {
-      "version": "2.9.16",
-      "requires": {
-        "@antv/async-hook": "^2.1.0",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "ajv": "^6.10.2",
-        "element-resize-event": "^3.0.3",
-        "eventemitter3": "^4.0.0",
-        "gl-matrix": "^3.1.0",
-        "inversify": "^5.0.1",
-        "inversify-inject-decorators": "^3.1.0",
-        "l7-tiny-sdf": "^0.0.3",
-        "l7hammerjs": "^0.0.7",
-        "lodash": "^4.17.15",
-        "reflect-metadata": "^0.1.13",
-        "viewport-mercator-project": "^6.2.1"
-      }
-    },
-    "@antv/l7-layers": {
-      "version": "2.9.16",
-      "requires": {
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-source": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "@mapbox/martini": "^0.2.0",
-        "@turf/helpers": "^6.1.4",
-        "@turf/meta": "^6.0.2",
-        "@turf/union": "^6.5.0",
-        "d3-array": "1",
-        "d3-color": "^1.4.0",
-        "d3-interpolate": "1.4.0",
-        "d3-scale": "2",
-        "earcut": "^2.2.1",
-        "eventemitter3": "^4.0.0",
-        "extrude-polyline": "^1.0.6",
-        "gl-matrix": "^3.1.0",
-        "gl-vec2": "^1.3.0",
-        "inversify": "^5.0.1",
-        "lodash": "^4.17.15",
-        "merge-json-schemas": "1.0.0",
-        "polyline-miter-util": "^1.0.1",
-        "reflect-metadata": "^0.1.13"
-      }
-    },
-    "@antv/l7-map": {
-      "version": "2.9.16",
-      "requires": {
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/unitbezier": "^0.0.0",
-        "eventemitter3": "^4.0.4",
-        "lodash": "^4.17.15"
-      }
-    },
-    "@antv/l7-maps": {
-      "version": "2.9.16",
-      "requires": {
-        "@amap/amap-jsapi-loader": "^0.0.3",
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-map": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "@types/amap-js-api": "^1.4.6",
-        "@types/mapbox-gl": "^1.11.2",
-        "gl-matrix": "^3.1.0",
-        "inversify": "^5.0.1",
-        "mapbox-gl": "^1.2.1",
-        "reflect-metadata": "^0.1.13",
-        "viewport-mercator-project": "^6.2.1"
-      }
-    },
-    "@antv/l7-renderer": {
-      "version": "2.9.16",
-      "requires": {
-        "@antv/l7-core": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "inversify": "^5.0.1",
-        "l7regl": "^0.0.20",
-        "lodash": "^4.17.15",
-        "reflect-metadata": "^0.1.13"
-      }
-    },
-    "@antv/l7-scene": {
-      "version": "2.9.16",
-      "requires": {
-        "@antv/l7-component": "2.9.16",
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-layers": "2.9.16",
-        "@antv/l7-maps": "2.9.16",
-        "@antv/l7-renderer": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "inversify": "^5.0.1",
-        "mapbox-gl": "^1.2.1",
-        "reflect-metadata": "^0.1.13"
-      }
-    },
-    "@antv/l7-source": {
-      "version": "2.9.16",
-      "requires": {
-        "@antv/async-hook": "^2.1.0",
-        "@antv/l7-core": "2.9.16",
-        "@antv/l7-utils": "2.9.16",
-        "@babel/runtime": "^7.7.7",
-        "@mapbox/geojson-rewind": "^0.5.2",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@turf/helpers": "^6.1.4",
-        "@turf/invariant": "^6.1.2",
-        "@turf/meta": "^6.0.2",
-        "d3-dsv": "^1.1.1",
-        "d3-hexbin": "^0.2.2",
-        "eventemitter3": "^4.0.0",
-        "inversify": "^5.0.1",
-        "lodash": "^4.17.15",
-        "pbf": "^3.2.1",
-        "reflect-metadata": "^0.1.13",
-        "supercluster": "^7.0.0"
-      }
-    },
-    "@antv/l7-utils": {
-      "version": "2.9.16",
-      "requires": {
-        "@babel/runtime": "^7.7.7",
-        "@turf/bbox-polygon": "^6.5.0",
-        "@turf/helpers": "^6.1.4",
-        "d3-color": "^1.4.0"
-      }
-    },
-    "@antv/l7plot": {
-      "version": "0.0.13",
-      "requires": {
-        "@antv/event-emitter": "^0.1.2",
-        "@antv/l7": "^2.9.14",
-        "@antv/l7plot-component": "^0.0.7",
-        "@antv/util": "^2.0.13",
-        "lodash-es": "^4.17.21",
-        "topojson-client": "^3.1.0"
-      }
-    },
-    "@antv/l7plot-component": {
-      "version": "0.0.7",
-      "requires": {
-        "@antv/dom-util": "^2.0.3",
-        "@antv/util": "^2.0.14"
-      }
-    },
-    "@antv/layout": {
-      "version": "0.1.31",
-      "requires": {
-        "@antv/g-webgpu": "0.5.5",
-        "@dagrejs/graphlib": "2.1.4",
-        "d3-force": "^2.0.1",
-        "ml-matrix": "^6.5.0"
-      }
-    },
     "@antv/matrix-util": {
       "version": "3.1.0-beta.3",
       "requires": {
@@ -9230,103 +8064,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "@antv/x6": {
-      "version": "1.32.8",
-      "requires": {
-        "csstype": "^3.0.3",
-        "jquery": "^3.5.1",
-        "jquery-mousewheel": "^3.1.13",
-        "lodash-es": "^4.17.15",
-        "mousetrap": "^1.6.5",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "@antv/x6-react-components": {
-      "version": "1.1.15",
-      "requires": {
-        "clamp": "^1.0.1",
-        "classnames": "^2.2.6",
-        "rc-dropdown": "^3.0.0-alpha.0",
-        "rc-util": "^4.15.7",
-        "react-color": "^2.17.3",
-        "react-resize-detector": "^6.6.4",
-        "ua-parser-js": "^0.7.20"
-      },
-      "dependencies": {
-        "rc-util": {
-          "version": "4.21.1",
-          "requires": {
-            "add-dom-event-listener": "^1.1.0",
-            "prop-types": "^15.5.10",
-            "react-is": "^16.12.0",
-            "react-lifecycles-compat": "^3.0.4",
-            "shallowequal": "^1.1.0"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1"
-        }
-      }
-    },
-    "@antv/x6-react-shape": {
-      "version": "1.6.1",
-      "requires": {}
-    },
-    "@antv/xflow": {
-      "version": "1.0.49",
-      "requires": {
-        "@antv/layout": "^0.1.22",
-        "@antv/x6": "^1.30.1",
-        "@antv/x6-react-components": "^1.1.15",
-        "@antv/x6-react-shape": "^1.5.2",
-        "@antv/xflow-core": "1.0.49",
-        "@antv/xflow-extension": "1.0.49",
-        "@antv/xflow-hook": "1.0.49"
-      }
-    },
-    "@antv/xflow-core": {
-      "version": "1.0.49",
-      "requires": {
-        "@antv/xflow-hook": "1.0.49",
-        "classnames": "^2.3.1",
-        "immer": "^9.0.7",
-        "mana-common": "^0.3.1",
-        "mana-syringe": "^0.2.2",
-        "reflect-metadata": "^0.1.13",
-        "rxjs": "^6.6.7"
-      }
-    },
-    "@antv/xflow-extension": {
-      "version": "1.0.49",
-      "requires": {
-        "@antv/xflow-core": "1.0.49",
-        "@antv/xflow-hook": "1.0.49",
-        "mana-syringe": "^0.2.2",
-        "moment": "^2.29.1",
-        "rc-field-form": "^1.22.0",
-        "react-color": "2.17.1",
-        "reflect-metadata": "^0.1.13"
-      },
-      "dependencies": {
-        "react-color": {
-          "version": "2.17.1",
-          "requires": {
-            "@icons/material": "^0.2.4",
-            "lodash": "^4.17.11",
-            "material-colors": "^1.2.1",
-            "prop-types": "^15.5.10",
-            "reactcss": "^1.2.0",
-            "tinycolor2": "^1.4.1"
-          }
-        }
-      }
-    },
-    "@antv/xflow-hook": {
-      "version": "1.0.49",
-      "requires": {
-        "toposort": "^2.0.2"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.18.6",
       "requires": {
@@ -9334,12 +8071,14 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.18.8"
+      "version": "7.18.8",
+      "dev": true
     },
     "@babel/core": {
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
       "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+      "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -9386,6 +8125,7 @@
     },
     "@babel/helper-compilation-targets": {
       "version": "7.18.9",
+      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.18.8",
         "@babel/helper-validator-option": "^7.18.6",
@@ -9417,6 +8157,7 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.18.9",
+      "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-module-imports": "^7.18.6",
@@ -9429,10 +8170,12 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.9"
+      "version": "7.18.9",
+      "dev": true
     },
     "@babel/helper-simple-access": {
       "version": "7.18.6",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -9452,10 +8195,12 @@
       "version": "7.18.6"
     },
     "@babel/helper-validator-option": {
-      "version": "7.18.6"
+      "version": "7.18.6",
+      "dev": true
     },
     "@babel/helpers": {
       "version": "7.18.9",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.18.6",
         "@babel/traverse": "^7.18.9",
@@ -9514,6 +8259,7 @@
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.18.6",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
@@ -9522,6 +8268,7 @@
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.18.10.tgz",
       "integrity": "sha512-gCy7Iikrpu3IZjYZolFE4M1Sm+nrh1/6za2Ewj77Z+XirT4TsbJcvOFOyF+fRPwU6AKKK136CZxx6L8AbSFG6A==",
+      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -9532,18 +8279,21 @@
     },
     "@babel/plugin-transform-react-jsx-development": {
       "version": "7.18.6",
+      "dev": true,
       "requires": {
         "@babel/plugin-transform-react-jsx": "^7.18.6"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
       "version": "7.18.6",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
       "version": "7.18.6",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
@@ -9601,12 +8351,6 @@
     },
     "@ctrl/tinycolor": {
       "version": "3.4.1"
-    },
-    "@dagrejs/graphlib": {
-      "version": "2.1.4",
-      "requires": {
-        "lodash": "^4.11.1"
-      }
     },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
@@ -9669,10 +8413,6 @@
       "version": "1.2.1",
       "dev": true
     },
-    "@icons/material": {
-      "version": "0.2.4",
-      "requires": {}
-    },
     "@jest/schemas": {
       "version": "28.1.3",
       "dev": true,
@@ -9682,6 +8422,7 @@
     },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
+      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -9702,44 +8443,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "@mapbox/geojson-rewind": {
-      "version": "0.5.2",
-      "requires": {
-        "get-stream": "^6.0.1",
-        "minimist": "^1.2.6"
-      }
-    },
-    "@mapbox/geojson-types": {
-      "version": "1.0.2"
-    },
-    "@mapbox/jsonlint-lines-primitives": {
-      "version": "2.0.2"
-    },
-    "@mapbox/mapbox-gl-supported": {
-      "version": "1.5.0",
-      "requires": {}
-    },
-    "@mapbox/martini": {
-      "version": "0.2.0"
-    },
-    "@mapbox/point-geometry": {
-      "version": "0.1.0"
-    },
-    "@mapbox/tiny-sdf": {
-      "version": "1.2.5"
-    },
-    "@mapbox/unitbezier": {
-      "version": "0.0.0"
-    },
-    "@mapbox/vector-tile": {
-      "version": "1.3.1",
-      "requires": {
-        "@mapbox/point-geometry": "~0.1.0"
-      }
-    },
-    "@mapbox/whoots-js": {
-      "version": "3.1.0"
     },
     "@motionone/animation": {
       "version": "10.13.1",
@@ -9898,6 +8601,7 @@
     },
     "@rollup/pluginutils": {
       "version": "4.2.1",
+      "dev": true,
       "requires": {
         "estree-walker": "^2.0.1",
         "picomatch": "^2.2.2"
@@ -9911,54 +8615,63 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.3.1.tgz",
       "integrity": "sha512-jDBKArXYO1u0B1dmd2Nf8Oy6aTF5vLDfLoO9Oon/GLkqZ/NiggYWZA+a2HpUMH4ITwNqS3z43k8LWApB8S583w==",
+      "dev": true,
       "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-attribute": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-6.3.1.tgz",
       "integrity": "sha512-dQzyJ4prwjcFd929T43Z8vSYiTlTu8eafV40Z2gO7zy/SV5GT+ogxRJRBIKWomPBOiaVXFg3jY4S5hyEN3IBjQ==",
+      "dev": true,
       "requires": {}
     },
     "@svgr/babel-plugin-remove-jsx-empty-expression": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-6.3.1.tgz",
       "integrity": "sha512-HBOUc1XwSU67fU26V5Sfb8MQsT0HvUyxru7d0oBJ4rA2s4HW3PhyAPC7fV/mdsSGpAvOdd8Wpvkjsr0fWPUO7A==",
+      "dev": true,
       "requires": {}
     },
     "@svgr/babel-plugin-replace-jsx-attribute-value": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.3.1.tgz",
       "integrity": "sha512-C12e6aN4BXAolRrI601gPn5MDFCRHO7C4TM8Kks+rDtl8eEq+NN1sak0eAzJu363x3TmHXdZn7+Efd2nr9I5dA==",
+      "dev": true,
       "requires": {}
     },
     "@svgr/babel-plugin-svg-dynamic-title": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.3.1.tgz",
       "integrity": "sha512-6NU55Mmh3M5u2CfCCt6TX29/pPneutrkJnnDCHbKZnjukZmmgUAZLtZ2g6ZoSPdarowaQmAiBRgAHqHmG0vuqA==",
+      "dev": true,
       "requires": {}
     },
     "@svgr/babel-plugin-svg-em-dimensions": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.3.1.tgz",
       "integrity": "sha512-HV1NGHYTTe1vCNKlBgq/gKuCSfaRlKcHIADn7P8w8U3Zvujdw1rmusutghJ1pZJV7pDt3Gt8ws+SVrqHnBO/Qw==",
+      "dev": true,
       "requires": {}
     },
     "@svgr/babel-plugin-transform-react-native-svg": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.3.1.tgz",
       "integrity": "sha512-2wZhSHvTolFNeKDAN/ZmIeSz2O9JSw72XD+o2bNp2QAaWqa8KGpn5Yk5WHso6xqfSAiRzAE+GXlsrBO4UP9LLw==",
+      "dev": true,
       "requires": {}
     },
     "@svgr/babel-plugin-transform-svg-component": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.3.1.tgz",
       "integrity": "sha512-cZ8Tr6ZAWNUFfDeCKn/pGi976iWSkS8ijmEYKosP+6ktdZ7lW9HVLHojyusPw3w0j8PI4VBeWAXAmi/2G7owxw==",
+      "dev": true,
       "requires": {}
     },
     "@svgr/babel-preset": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-6.3.1.tgz",
       "integrity": "sha512-tQtWtzuMMQ3opH7je+MpwfuRA1Hf3cKdSgTtAYwOBDfmhabP7rcTfBi3E7V3MuwJNy/Y02/7/RutvwS1W4Qv9g==",
+      "dev": true,
       "requires": {
         "@svgr/babel-plugin-add-jsx-attribute": "^6.3.1",
         "@svgr/babel-plugin-remove-jsx-attribute": "^6.3.1",
@@ -9974,6 +8687,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.3.1.tgz",
       "integrity": "sha512-Sm3/7OdXbQreemf9aO25keerZSbnKMpGEfmH90EyYpj1e8wMD4TuwJIb3THDSgRMWk1kYJfSRulELBy4gVgZUA==",
+      "dev": true,
       "requires": {
         "@svgr/plugin-jsx": "^6.3.1",
         "camelcase": "^6.2.0",
@@ -9984,6 +8698,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-6.3.1.tgz",
       "integrity": "sha512-NgyCbiTQIwe3wHe/VWOUjyxmpUmsrBjdoIxKpXt3Nqc3TN30BpJG22OxBvVzsAh9jqep0w0/h8Ywvdk3D9niNQ==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.4",
         "entities": "^4.3.0"
@@ -9993,6 +8708,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-6.3.1.tgz",
       "integrity": "sha512-r9+0mYG3hD4nNtUgsTXWGYJomv/bNd7kC16zvsM70I/bGeoCi/3lhTmYqeN6ChWX317OtQCSZZbH4wq9WwoXbw==",
+      "dev": true,
       "requires": {
         "@babel/core": "^7.18.5",
         "@svgr/babel-preset": "^6.3.1",
@@ -10073,44 +8789,6 @@
         "tippy.js": "^6.3.1"
       }
     },
-    "@turf/bbox-polygon": {
-      "version": "6.5.0",
-      "requires": {
-        "@turf/helpers": "^6.5.0"
-      }
-    },
-    "@turf/helpers": {
-      "version": "6.5.0"
-    },
-    "@turf/invariant": {
-      "version": "6.5.0",
-      "requires": {
-        "@turf/helpers": "^6.5.0"
-      }
-    },
-    "@turf/meta": {
-      "version": "6.5.0",
-      "requires": {
-        "@turf/helpers": "^6.5.0"
-      }
-    },
-    "@turf/union": {
-      "version": "6.5.0",
-      "requires": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "polygon-clipping": "^0.15.3"
-      }
-    },
-    "@types/acorn": {
-      "version": "4.0.6",
-      "requires": {
-        "@types/estree": "*"
-      }
-    },
-    "@types/amap-js-api": {
-      "version": "1.4.10"
-    },
     "@types/aria-query": {
       "version": "4.2.2"
     },
@@ -10139,10 +8817,8 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.41"
-    },
-    "@types/geojson": {
-      "version": "7946.0.10"
+      "version": "0.0.41",
+      "dev": true
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -10175,9 +8851,6 @@
         }
       }
     },
-    "@types/js-cookie": {
-      "version": "2.2.7"
-    },
     "@types/json-schema": {
       "version": "7.0.11",
       "dev": true
@@ -10186,18 +8859,13 @@
       "version": "0.0.29",
       "dev": true
     },
-    "@types/mapbox-gl": {
-      "version": "1.13.3",
-      "requires": {
-        "@types/geojson": "*"
-      }
-    },
     "@types/node": {
       "version": "18.0.6",
       "dev": true
     },
     "@types/parse-json": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.5"
@@ -10256,9 +8924,6 @@
       "requires": {
         "@types/react": "*"
       }
-    },
-    "@types/resize-observer-browser": {
-      "version": "0.1.7"
     },
     "@types/scheduler": {
       "version": "0.16.2"
@@ -10423,6 +9088,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.0.1.tgz",
       "integrity": "sha512-uINzNHmjrbunlFtyVkST6lY1ewSfz/XwLufG0PIqvLGnpk2nOIOa/1CACTDNcKi1/RwaCzJLmsXwm1NsUVV/NA==",
+      "dev": true,
       "requires": {
         "@babel/core": "^7.18.10",
         "@babel/plugin-transform-react-jsx": "^7.18.10",
@@ -10439,9 +9105,6 @@
     "@webgpu/types": {
       "version": "0.0.31"
     },
-    "@xobotyi/scrollbar-width": {
-      "version": "1.9.5"
-    },
     "acorn": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
@@ -10453,14 +9116,9 @@
       "dev": true,
       "requires": {}
     },
-    "add-dom-event-listener": {
-      "version": "1.1.0",
-      "requires": {
-        "object-assign": "4.x"
-      }
-    },
     "ajv": {
       "version": "6.12.6",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10477,7 +9135,9 @@
       }
     },
     "amdefine": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg=="
     },
     "ansi-regex": {
       "version": "5.0.1"
@@ -10600,9 +9260,6 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
-    "as-number": {
-      "version": "1.0.0"
-    },
     "assertion-error": {
       "version": "1.1.0",
       "dev": true
@@ -10610,9 +9267,6 @@
     "ast-types-flow": {
       "version": "0.0.7",
       "dev": true
-    },
-    "async": {
-      "version": "3.2.4"
     },
     "async-validator": {
       "version": "4.2.5"
@@ -10675,6 +9329,7 @@
     },
     "browserslist": {
       "version": "4.21.2",
+      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001366",
         "electron-to-chromium": "^1.4.188",
@@ -10693,16 +9348,19 @@
       }
     },
     "callsites": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dev": true
     },
     "camelcase": {
-      "version": "6.3.0"
+      "version": "6.3.0",
+      "dev": true
     },
     "camelize": {
       "version": "1.0.0"
     },
     "caniuse-lite": {
-      "version": "1.0.30001367"
+      "version": "1.0.30001367",
+      "dev": true
     },
     "canvg": {
       "version": "3.0.10",
@@ -10748,9 +9406,6 @@
     "check-error": {
       "version": "1.0.2",
       "dev": true
-    },
-    "clamp": {
-      "version": "1.0.1"
     },
     "classnames": {
       "version": "2.3.1"
@@ -10814,9 +9469,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.20.3"
-    },
     "compute-scroll-into-view": {
       "version": "1.0.17"
     },
@@ -10835,13 +9487,14 @@
     },
     "convert-source-map": {
       "version": "1.8.0",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
     },
     "copy-anything": {
       "version": "2.0.6",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "is-what": "^3.14.1"
       }
@@ -10862,6 +9515,7 @@
     },
     "cosmiconfig": {
       "version": "7.0.1",
+      "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -10888,13 +9542,6 @@
     "css-color-keywords": {
       "version": "1.0.0"
     },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
-    },
     "css-line-break": {
       "version": "2.1.0",
       "requires": {
@@ -10909,42 +9556,18 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
-    "css-tree": {
-      "version": "1.1.3",
-      "requires": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      }
-    },
     "css.escape": {
       "version": "1.5.1",
       "dev": true
     },
-    "csscolorparser": {
-      "version": "1.0.3"
-    },
     "csstype": {
       "version": "3.1.0"
-    },
-    "d3-array": {
-      "version": "1.2.4"
-    },
-    "d3-collection": {
-      "version": "1.0.7"
     },
     "d3-color": {
       "version": "1.4.1"
     },
     "d3-dispatch": {
       "version": "2.0.0"
-    },
-    "d3-dsv": {
-      "version": "1.2.0",
-      "requires": {
-        "commander": "2",
-        "iconv-lite": "0.4",
-        "rw": "1"
-      }
     },
     "d3-ease": {
       "version": "1.0.7"
@@ -10956,12 +9579,6 @@
         "d3-quadtree": "1 - 2",
         "d3-timer": "1 - 2"
       }
-    },
-    "d3-format": {
-      "version": "1.4.5"
-    },
-    "d3-hexbin": {
-      "version": "0.2.2"
     },
     "d3-hierarchy": {
       "version": "2.0.0"
@@ -10977,26 +9594,6 @@
     },
     "d3-regression": {
       "version": "1.3.10"
-    },
-    "d3-scale": {
-      "version": "2.2.2",
-      "requires": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
-    },
-    "d3-time": {
-      "version": "1.1.0"
-    },
-    "d3-time-format": {
-      "version": "2.3.0",
-      "requires": {
-        "d3-time": "1"
-      }
     },
     "d3-timer": {
       "version": "1.0.10"
@@ -11057,6 +9654,12 @@
       "version": "0.1.4",
       "dev": true
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.4",
       "requires": {
@@ -11109,14 +9712,9 @@
         "minimatch": "^3.0.4"
       }
     },
-    "earcut": {
-      "version": "2.2.4"
-    },
     "electron-to-chromium": {
-      "version": "1.4.195"
-    },
-    "element-resize-event": {
-      "version": "3.0.6"
+      "version": "1.4.195",
+      "dev": true
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -11125,10 +9723,12 @@
     "entities": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
+      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+      "dev": true
     },
     "errno": {
       "version": "0.1.8",
+      "dev": true,
       "optional": true,
       "requires": {
         "prr": "~1.0.1"
@@ -11136,19 +9736,15 @@
     },
     "error-ex": {
       "version": "1.3.2",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       },
       "dependencies": {
         "is-arrayish": {
-          "version": "0.2.1"
+          "version": "0.2.1",
+          "dev": true
         }
-      }
-    },
-    "error-stack-parser": {
-      "version": "2.1.4",
-      "requires": {
-        "stackframe": "^1.3.4"
       }
     },
     "es-abstract": {
@@ -11196,6 +9792,7 @@
     },
     "esbuild": {
       "version": "0.14.49",
+      "dev": true,
       "requires": {
         "esbuild-android-64": "0.14.49",
         "esbuild-android-arm64": "0.14.49",
@@ -11221,10 +9818,12 @@
     },
     "esbuild-linux-64": {
       "version": "0.14.49",
+      "dev": true,
       "optional": true
     },
     "escalade": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -11621,7 +10220,8 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -11630,28 +10230,9 @@
     "eventemitter3": {
       "version": "4.0.7"
     },
-    "extrude-polyline": {
-      "version": "1.0.6",
-      "requires": {
-        "as-number": "^1.0.0",
-        "gl-vec2": "^1.0.0",
-        "polyline-miter-util": "^1.0.1"
-      }
-    },
-    "falafel": {
-      "version": "2.2.5",
-      "requires": {
-        "acorn": "^7.1.1",
-        "isarray": "^2.0.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1"
-        }
-      }
-    },
     "fast-deep-equal": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -11678,17 +10259,12 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "dev": true
-    },
-    "fast-shallow-equal": {
-      "version": "1.0.0"
-    },
-    "fastest-stable-stringify": {
-      "version": "2.0.2"
     },
     "fastq": {
       "version": "1.13.0",
@@ -11748,6 +10324,58 @@
         "rollup": "^0.25.8",
         "tape": "^4.5.1",
         "uglify-js": "^2.6.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "rollup": {
+          "version": "0.25.8",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.25.8.tgz",
+          "integrity": "sha512-a2S4Bh3bgrdO4BhKr2E4nZkjTvrJ2m2bWjMTzVYtoqSCn0HnuxosXnaJUHrMEziOWr3CzL9GjilQQKcyCQpJoA==",
+          "requires": {
+            "chalk": "^1.1.1",
+            "minimist": "^1.2.0",
+            "source-map-support": "^0.3.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
+        }
       }
     },
     "follow-redirects": {
@@ -11792,6 +10420,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -11814,10 +10443,14 @@
       "version": "1.2.3"
     },
     "gensync": {
-      "version": "1.0.0-beta.2"
+      "version": "1.0.0-beta.2",
+      "dev": true
     },
-    "geojson-vt": {
-      "version": "3.2.1"
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -11830,9 +10463,6 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
       }
-    },
-    "get-stream": {
-      "version": "6.0.1"
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -11884,6 +10514,7 @@
     },
     "graceful-fs": {
       "version": "4.2.10",
+      "dev": true,
       "optional": true
     },
     "grapheme-splitter": {
@@ -11900,9 +10531,6 @@
         "lodash": "^4.17.15"
       }
     },
-    "grid-index": {
-      "version": "1.1.0"
-    },
     "hammerjs": {
       "version": "2.0.8"
     },
@@ -11914,12 +10542,16 @@
     },
     "has-ansi": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "requires": {
         "ansi-regex": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1"
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
         }
       }
     },
@@ -11971,24 +10603,13 @@
         "text-segmentation": "^1.0.3"
       }
     },
-    "hyphenate-style-name": {
-      "version": "1.0.4"
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "ieee754": {
-      "version": "1.2.1"
-    },
     "ignore": {
       "version": "5.2.0",
       "dev": true
     },
     "image-size": {
       "version": "0.5.5",
+      "dev": true,
       "optional": true
     },
     "immer": {
@@ -11996,6 +10617,7 @@
     },
     "import-fresh": {
       "version": "3.3.0",
+      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -12018,12 +10640,6 @@
     },
     "inherits": {
       "version": "2.0.4"
-    },
-    "inline-style-prefixer": {
-      "version": "6.0.1",
-      "requires": {
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "insert-css": {
       "version": "2.0.0",
@@ -12090,8 +10706,20 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
     "is-glob": {
@@ -12149,17 +10777,20 @@
     },
     "is-what": {
       "version": "3.14.1",
-      "devOptional": true
+      "dev": true
     },
-    "isarray": {
-      "version": "2.0.5"
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "isexe": {
       "version": "2.0.0",
       "dev": true
-    },
-    "isobject": {
-      "version": "3.0.1"
     },
     "jest-diff": {
       "version": "28.1.3",
@@ -12217,15 +10848,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.6.0"
-    },
-    "jquery-mousewheel": {
-      "version": "3.1.13"
-    },
-    "js-cookie": {
-      "version": "2.2.1"
-    },
     "js-tokens": {
       "version": "4.0.0"
     },
@@ -12240,10 +10862,12 @@
       "version": "2.5.2"
     },
     "json-parse-even-better-errors": {
-      "version": "2.3.1"
+      "version": "2.3.1",
+      "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -12262,7 +10886,8 @@
       }
     },
     "json5": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "dev": true
     },
     "jspdf": {
       "version": "2.5.1",
@@ -12285,40 +10910,10 @@
         "object.assign": "^4.1.2"
       }
     },
-    "kdbush": {
-      "version": "3.0.0"
-    },
     "kind-of": {
       "version": "3.2.2",
       "requires": {
         "is-buffer": "^1.1.5"
-      }
-    },
-    "l7-tiny-sdf": {
-      "version": "0.0.3"
-    },
-    "l7eval5": {
-      "version": "0.0.3",
-      "requires": {
-        "@babel/runtime": "^7.8.4",
-        "@types/acorn": "^4.0.5",
-        "@types/estree": "0.0.41",
-        "acorn": "^7.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "7.4.1"
-        }
-      }
-    },
-    "l7hammerjs": {
-      "version": "0.0.7"
-    },
-    "l7regl": {
-      "version": "0.0.20",
-      "requires": {
-        "falafel": "^2.2.4",
-        "l7eval5": "^0.0.3"
       }
     },
     "language-subtag-registry": {
@@ -12337,7 +10932,7 @@
     },
     "less": {
       "version": "4.1.3",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "copy-anything": "^2.0.1",
         "errno": "^0.1.1",
@@ -12360,7 +10955,8 @@
       }
     },
     "lines-and-columns": {
-      "version": "1.2.4"
+      "version": "1.2.4",
+      "dev": true
     },
     "local-pkg": {
       "version": "0.4.2",
@@ -12377,30 +10973,12 @@
     "lodash": {
       "version": "4.17.21"
     },
-    "lodash-es": {
-      "version": "4.17.21"
-    },
-    "lodash.isarray": {
-      "version": "4.0.0"
-    },
-    "lodash.isnil": {
-      "version": "4.0.0"
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6"
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "dev": true
     },
-    "lodash.mergewith": {
-      "version": "4.6.2"
-    },
     "lodash.throttle": {
       "version": "4.1.1"
-    },
-    "lodash.uniq": {
-      "version": "4.5.0"
     },
     "longest": {
       "version": "1.0.1"
@@ -12434,12 +11012,14 @@
       "version": "0.26.2",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
       "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
       "version": "2.1.0",
+      "dev": true,
       "optional": true,
       "requires": {
         "pify": "^4.0.1",
@@ -12448,65 +11028,13 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
+          "dev": true,
           "optional": true
         }
       }
     },
-    "mana-common": {
-      "version": "0.3.1"
-    },
-    "mana-syringe": {
-      "version": "0.2.2",
-      "requires": {
-        "inversify": "^5.0.1"
-      }
-    },
-    "mapbox-gl": {
-      "version": "1.13.2",
-      "requires": {
-        "@mapbox/geojson-rewind": "^0.5.0",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.1",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.2",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.2.1",
-        "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^7.1.0",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.1"
-      }
-    },
-    "material-colors": {
-      "version": "1.2.6"
-    },
-    "mdn-data": {
-      "version": "2.0.14"
-    },
     "memoize-one": {
       "version": "6.0.0"
-    },
-    "merge-json-schemas": {
-      "version": "1.0.0",
-      "requires": {
-        "lodash.isarray": "^4.0.0",
-        "lodash.isnil": "^4.0.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.mergewith": "^4.6.0",
-        "lodash.uniq": "^4.5.0"
-      }
     },
     "merge2": {
       "version": "1.4.1",
@@ -12526,6 +11054,7 @@
     },
     "mime": {
       "version": "1.6.0",
+      "dev": true,
       "optional": true
     },
     "mime-db": {
@@ -12580,30 +11109,12 @@
     "moment": {
       "version": "2.29.4"
     },
-    "mousetrap": {
-      "version": "1.6.5"
-    },
     "ms": {
       "version": "2.1.2"
     },
-    "murmurhash-js": {
-      "version": "1.0.0"
-    },
-    "nano-css": {
-      "version": "5.3.5",
-      "requires": {
-        "css-tree": "^1.1.2",
-        "csstype": "^3.0.6",
-        "fastest-stable-stringify": "^2.0.2",
-        "inline-style-prefixer": "^6.0.0",
-        "rtl-css-js": "^1.14.0",
-        "sourcemap-codec": "^1.4.8",
-        "stacktrace-js": "^2.0.2",
-        "stylis": "^4.0.6"
-      }
-    },
     "nanoid": {
-      "version": "3.3.4"
+      "version": "3.3.4",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -12611,6 +11122,7 @@
     },
     "needle": {
       "version": "3.1.0",
+      "dev": true,
       "optional": true,
       "requires": {
         "debug": "^3.2.6",
@@ -12620,6 +11132,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
+          "dev": true,
           "optional": true,
           "requires": {
             "ms": "^2.1.1"
@@ -12627,6 +11140,7 @@
         },
         "iconv-lite": {
           "version": "0.6.3",
+          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12635,7 +11149,8 @@
       }
     },
     "node-releases": {
-      "version": "2.0.6"
+      "version": "2.0.6",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1"
@@ -12703,6 +11218,17 @@
         "wrappy": "1"
       }
     },
+    "open": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
+      "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+      "dev": true,
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "dev": true,
@@ -12735,12 +11261,14 @@
     },
     "parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
     },
     "parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -12750,7 +11278,7 @@
     },
     "parse-node-version": {
       "version": "1.0.1",
-      "devOptional": true
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -12767,18 +11295,12 @@
       "version": "1.0.7"
     },
     "path-type": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "pathval": {
       "version": "1.1.1",
       "dev": true
-    },
-    "pbf": {
-      "version": "3.2.1",
-      "requires": {
-        "ieee754": "^1.1.12",
-        "resolve-protobuf-schema": "^2.1.0"
-      }
     },
     "pdfast": {
       "version": "0.2.0"
@@ -12788,20 +11310,16 @@
       "optional": true
     },
     "picocolors": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "picomatch": {
       "version": "2.3.1"
     },
     "pify": {
       "version": "4.0.1",
+      "dev": true,
       "optional": true
-    },
-    "polygon-clipping": {
-      "version": "0.15.3",
-      "requires": {
-        "splaytree": "^3.1.0"
-      }
     },
     "polyline-miter-util": {
       "version": "1.0.1",
@@ -12828,6 +11346,7 @@
       "version": "8.4.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
       "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -12836,9 +11355,6 @@
     },
     "postcss-value-parser": {
       "version": "4.2.0"
-    },
-    "potpack": {
-      "version": "1.0.2"
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -12882,24 +11398,20 @@
         }
       }
     },
-    "protocol-buffers-schema": {
-      "version": "3.6.0"
-    },
     "prr": {
       "version": "1.0.1",
+      "dev": true,
       "optional": true
     },
     "punycode": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "quickselect": {
-      "version": "2.0.0"
     },
     "raf": {
       "version": "3.4.1",
@@ -12968,15 +11480,6 @@
         "classnames": "^2.2.6",
         "rc-motion": "^2.6.1",
         "rc-util": "^5.21.2"
-      }
-    },
-    "rc-dropdown": {
-      "version": "3.6.2",
-      "requires": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-trigger": "^5.0.4",
-        "rc-util": "^5.17.0"
       }
     },
     "rc-field-form": {
@@ -13303,17 +11806,6 @@
         }
       }
     },
-    "react-color": {
-      "version": "2.17.3",
-      "requires": {
-        "@icons/material": "^0.2.4",
-        "lodash": "^4.17.11",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      }
-    },
     "react-component-export-image": {
       "version": "1.0.6",
       "requires": {
@@ -13358,9 +11850,6 @@
     "react-is": {
       "version": "18.2.0"
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4"
-    },
     "react-redux": {
       "version": "8.0.2",
       "requires": {
@@ -13375,15 +11864,8 @@
     "react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
-      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ=="
-    },
-    "react-resize-detector": {
-      "version": "6.7.8",
-      "requires": {
-        "@types/resize-observer-browser": "^0.1.6",
-        "lodash": "^4.17.21",
-        "resize-observer-polyfill": "^1.5.1"
-      }
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
+      "dev": true
     },
     "react-router": {
       "version": "6.3.0",
@@ -13425,35 +11907,6 @@
       "requires": {
         "prop-types": "^15.7.2",
         "uuid": "^7.0.3"
-      }
-    },
-    "react-universal-interface": {
-      "version": "0.6.2",
-      "requires": {}
-    },
-    "react-use": {
-      "version": "17.3.1",
-      "requires": {
-        "@types/js-cookie": "^2.2.6",
-        "@xobotyi/scrollbar-width": "^1.9.5",
-        "copy-to-clipboard": "^3.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-shallow-equal": "^1.0.0",
-        "js-cookie": "^2.2.1",
-        "nano-css": "^5.3.1",
-        "react-universal-interface": "^0.6.2",
-        "resize-observer-polyfill": "^1.5.1",
-        "screenfull": "^5.1.0",
-        "set-harmonic-interval": "^1.0.1",
-        "throttle-debounce": "^3.0.1",
-        "ts-easing": "^0.2.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "reactcss": {
-      "version": "1.2.3",
-      "requires": {
-        "lodash": "^4.0.1"
       }
     },
     "redent": {
@@ -13502,6 +11955,12 @@
     "repeat-string": {
       "version": "1.6.1"
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
     "reselect": {
       "version": "4.1.6"
     },
@@ -13517,13 +11976,8 @@
       }
     },
     "resolve-from": {
-      "version": "4.0.0"
-    },
-    "resolve-protobuf-schema": {
-      "version": "2.1.0",
-      "requires": {
-        "protocol-buffers-schema": "^3.3.1"
-      }
+      "version": "4.0.0",
+      "dev": true
     },
     "resumer": {
       "version": "0.0.0",
@@ -13555,47 +12009,58 @@
       }
     },
     "rollup": {
-      "version": "0.25.8",
+      "version": "2.78.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.0.tgz",
+      "integrity": "sha512-4+YfbQC9QEVvKTanHhIAFVUFSRsezvQF8vFOJwtGfb9Bb+r014S+qryr9PSmw8x6sMnPkmFBGAvIFVQxvJxjtg==",
+      "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "minimist": "^1.2.0",
-        "source-map-support": "^0.3.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1"
-        },
-        "ansi-styles": {
-          "version": "2.2.1"
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5"
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0"
-        }
+        "fsevents": "~2.3.2"
       }
     },
-    "rtl-css-js": {
-      "version": "1.15.0",
+    "rollup-plugin-visualizer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.7.1.tgz",
+      "integrity": "sha512-E/IgOMnmXKlc6ICyf53ok1b6DxPeNVUs3R0kYYPuDpGfofT4bkiG+KtSMlGjMACFmfwbbqTVDZBIF7sMZVKJbA==",
+      "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "nanoid": "^3.3.4",
+        "open": "^8.4.0",
+        "source-map": "^0.7.3",
+        "yargs": "^17.5.1"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.5.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+          "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        }
       }
     },
     "run-parallel": {
@@ -13610,25 +12075,18 @@
     "rw": {
       "version": "1.3.3"
     },
-    "rxjs": {
-      "version": "6.6.7",
-      "requires": {
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1"
-        }
-      }
-    },
     "safe-buffer": {
-      "version": "5.1.2"
+      "version": "5.1.2",
+      "dev": true
     },
     "safer-buffer": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true,
+      "optional": true
     },
     "sax": {
       "version": "1.2.4",
+      "dev": true,
       "optional": true
     },
     "scheduler": {
@@ -13638,9 +12096,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "screenfull": {
-      "version": "5.2.0"
-    },
     "scroll-into-view-if-needed": {
       "version": "2.2.29",
       "requires": {
@@ -13648,10 +12103,8 @@
       }
     },
     "semver": {
-      "version": "6.3.0"
-    },
-    "set-harmonic-interval": {
-      "version": "1.0.1"
+      "version": "6.3.0",
+      "dev": true
     },
     "shallowequal": {
       "version": "1.1.0"
@@ -13693,19 +12146,26 @@
       "dev": true
     },
     "source-map": {
-      "version": "0.6.1"
+      "version": "0.6.1",
+      "dev": true,
+      "optional": true
     },
     "source-map-js": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "source-map-support": {
       "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
+      "integrity": "sha512-9O4+y9n64RewmFoKUZ/5Tx9IHIcXM6Q+RTSw6ehnqybUz4a7iwR3Eaw80uLtqqQ5D0C+5H03D4KKGo9PdP33Gg==",
       "requires": {
         "source-map": "0.1.32"
       },
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+          "integrity": "sha512-htQyLrrRLkQ87Zfrir4/yN+vAUd6DNjVayEjTSHXu29AYQJw57I4/xEL/M6p6E/woPNJwvZt6rVlzc7gFEJccQ==",
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -13713,46 +12173,34 @@
       }
     },
     "sourcemap-codec": {
-      "version": "1.4.8"
-    },
-    "splaytree": {
-      "version": "3.1.1"
-    },
-    "stack-generator": {
-      "version": "2.0.10",
-      "requires": {
-        "stackframe": "^1.3.4"
-      }
+      "version": "1.4.8",
+      "dev": true
     },
     "stackblur-canvas": {
       "version": "2.5.0",
       "optional": true
     },
-    "stackframe": {
-      "version": "1.3.4"
-    },
-    "stacktrace-gps": {
-      "version": "3.1.2",
-      "requires": {
-        "source-map": "0.5.6",
-        "stackframe": "^1.3.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.6"
-        }
-      }
-    },
-    "stacktrace-js": {
-      "version": "2.0.2",
-      "requires": {
-        "error-stack-parser": "^2.0.6",
-        "stack-generator": "^2.0.5",
-        "stacktrace-gps": "^3.0.4"
-      }
-    },
     "string-convert": {
       "version": "0.2.1"
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        }
+      }
     },
     "string.prototype.matchall": {
       "version": "4.0.7",
@@ -13853,15 +12301,6 @@
         }
       }
     },
-    "stylis": {
-      "version": "4.1.1"
-    },
-    "supercluster": {
-      "version": "7.1.5",
-      "requires": {
-        "kdbush": "^3.0.0"
-      }
-    },
     "supports-color": {
       "version": "7.2.0",
       "requires": {
@@ -13874,7 +12313,8 @@
     "svg-parser": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
-      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
+      "dev": true
     },
     "svg-pathdata": {
       "version": "6.0.3",
@@ -13910,9 +12350,6 @@
       "version": "0.2.0",
       "dev": true
     },
-    "throttle-debounce": {
-      "version": "3.0.1"
-    },
     "through": {
       "version": "2.3.8"
     },
@@ -13925,9 +12362,6 @@
     "tinypool": {
       "version": "0.2.4",
       "dev": true
-    },
-    "tinyqueue": {
-      "version": "2.0.3"
     },
     "tinyspy": {
       "version": "1.0.0",
@@ -13955,18 +12389,6 @@
     },
     "toggle-selection": {
       "version": "1.0.6"
-    },
-    "topojson-client": {
-      "version": "3.1.0",
-      "requires": {
-        "commander": "2"
-      }
-    },
-    "toposort": {
-      "version": "2.0.2"
-    },
-    "ts-easing": {
-      "version": "0.2.0"
     },
     "tsconfig-paths": {
       "version": "3.14.1",
@@ -14028,9 +12450,6 @@
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
-    "ua-parser-js": {
-      "version": "0.7.31"
-    },
     "uglify-js": {
       "version": "2.8.29",
       "requires": {
@@ -14059,6 +12478,7 @@
     },
     "update-browserslist-db": {
       "version": "1.0.5",
+      "dev": true,
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -14066,6 +12486,7 @@
     },
     "uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -14084,9 +12505,6 @@
       "version": "1.2.0",
       "requires": {}
     },
-    "utility-types": {
-      "version": "3.10.0"
-    },
     "utrie": {
       "version": "1.0.2",
       "requires": {
@@ -14100,17 +12518,11 @@
       "version": "2.3.0",
       "dev": true
     },
-    "viewport-mercator-project": {
-      "version": "6.2.3",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "gl-matrix": "^3.0.0"
-      }
-    },
     "vite": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.8.tgz",
       "integrity": "sha512-AOZ4eN7mrkJiOLuw8IA7piS4IdOQyQCA81GxGsAQvAZzMRi9ZwGB3TOaYsj4uLAWK46T5L4AfQ6InNGlxX30IQ==",
+      "dev": true,
       "requires": {
         "esbuild": "^0.14.47",
         "fsevents": "~2.3.2",
@@ -14123,6 +12535,7 @@
           "version": "2.77.3",
           "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
           "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+          "dev": true,
           "requires": {
             "fsevents": "~2.3.2"
           }
@@ -14136,21 +12549,13 @@
         "@rollup/pluginutils": "^4.2.1",
         "@types/eslint": "^8.4.5",
         "rollup": "^2.77.0"
-      },
-      "dependencies": {
-        "rollup": {
-          "version": "2.77.0",
-          "dev": true,
-          "requires": {
-            "fsevents": "~2.3.2"
-          }
-        }
       }
     },
     "vite-plugin-svgr": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-2.2.1.tgz",
       "integrity": "sha512-+EqwahbwjETJH/ssA/66dNYyKN1cO0AStq96MuXmq5maU7AePBMf2lDKfQna49tJZAjtRz+R899BWCsUUP45Fg==",
+      "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.2.1",
         "@svgr/core": "^6.3.1"
@@ -14171,14 +12576,6 @@
         "tinypool": "^0.2.4",
         "tinyspy": "^1.0.0",
         "vite": "^2.9.12 || ^3.0.0-0"
-      }
-    },
-    "vt-pbf": {
-      "version": "3.1.3",
-      "requires": {
-        "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.2.1"
       }
     },
     "which": {
@@ -14208,8 +12605,25 @@
     "wordwrap": {
       "version": "0.0.2"
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2"
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",
@@ -14218,7 +12632,8 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.2"
+      "version": "1.10.2",
+      "dev": true
     },
     "yargs": {
       "version": "3.10.0",
@@ -14233,6 +12648,12 @@
           "version": "1.2.1"
         }
       }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,15 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@ant-design/charts": "1.4.2",
     "@ant-design/colors": "6.0.0",
     "@ant-design/icons": "4.7.0",
+    "@ant-design/plots": "1.2.1",
     "@antv/algorithm": "0.1.24",
     "@antv/g6": "4.6.18",
     "@react-spring/web": "9.5.2",
     "@reduxjs/toolkit": "1.8.4",
     "@tippyjs/react": "4.2.6",
-    "@vitejs/plugin-react": "2.0.1",
     "antd": "4.22.5",
     "axios": "0.27.2",
     "framer-motion": "6.5.1",
@@ -32,15 +31,14 @@
     "redux-persist": "6.0.0",
     "redux-thunk": "2.4.1",
     "styled-components": "5.3.5",
-    "use-debounce": "8.0.3",
-    "vite": "3.0.8",
-    "vite-plugin-svgr": "2.2.1"
+    "use-debounce": "8.0.3"
   },
   "scripts": {
     "start": "vite --port 3000 --host",
     "start:local": "VITE_BACKEND_API_BASE_URL=https://circlesapi.csesoc.app vite --port 3000 --host",
-    "build": "export NODE_OPTIONS=--max_old_space_size=4096; vite build",
+    "build": "vite build",
     "preview": "vite preview --port 3000 --host",
+    "preview:local": "VITE_BACKEND_API_BASE_URL=https://circlesapi.csesoc.app vite preview --port 3000 --host",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "lint": "eslint src/**/*.{ts,tsx}",
@@ -75,6 +73,7 @@
     "@types/styled-components": "5.1.26",
     "@typescript-eslint/eslint-plugin": "5.33.1",
     "@typescript-eslint/parser": "5.33.1",
+    "@vitejs/plugin-react": "2.0.1",
     "eslint": "8.22.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-airbnb-typescript": "17.0.0",
@@ -87,7 +86,9 @@
     "eslint-plugin-simple-import-sort": "7.0.0",
     "less": "4.1.3",
     "typescript": "4.7.4",
+    "vite": "3.0.8",
     "vite-plugin-eslint": "1.7.0",
+    "vite-plugin-svgr": "2.2.1",
     "vitest": "0.22.0"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,9 +5,9 @@ import {
   Routes,
 } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
-import ErrorBoundary from 'components/ErrorBoundary';
 import type { RootState } from 'config/store';
 import { darkTheme, GlobalStyles, lightTheme } from 'config/theme';
+import ErrorBoundary from './components/ErrorBoundary';
 import PageLoading from './components/PageLoading';
 import CourseSelector from './pages/CourseSelector';
 import DegreeWizard from './pages/DegreeWizard';

--- a/frontend/src/components/DraggableTab/DraggableTab.tsx
+++ b/frontend/src/components/DraggableTab/DraggableTab.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  Suspense, useEffect, useRef, useState,
+} from 'react';
 import type { DraggingStyle } from 'react-beautiful-dnd';
 import { useDispatch, useSelector } from 'react-redux';
 import { CloseOutlined } from '@ant-design/icons';
@@ -58,31 +60,33 @@ const DraggableTab = ({ tabName, index }: Props) => {
   };
 
   return (
-    <Draggable key={tabName} draggableId={tabName} index={index}>
-      {(draggableProvided) => (
-        <S.DraggableTabWrapper
-          role="tab"
-          active={index === active}
-          onClick={() => dispatch(setActiveTab(index))}
-          ref={(r) => {
-            ref.current = r;
-            draggableProvided.innerRef(r);
-          }}
-          {...draggableProvided.draggableProps}
-          {...draggableProvided.dragHandleProps}
-          style={getDraggableStyle(draggableProvided.draggableProps.style as DraggingStyle)}
-          onMouseUp={handleMouseUp}
-        >
-          <S.TabNameWrapper>{tabName}</S.TabNameWrapper>
-          <Button
-            type="text"
-            size="small"
-            icon={<CloseOutlined style={{ fontSize: '12px', color: theme.text }} />}
-            onClick={handleOnClick}
-          />
-        </S.DraggableTabWrapper>
-      )}
-    </Draggable>
+    <Suspense fallback={<div>Loading...</div>}>
+      <Draggable key={tabName} draggableId={tabName} index={index}>
+        {(draggableProvided) => (
+          <S.DraggableTabWrapper
+            role="tab"
+            active={index === active}
+            onClick={() => dispatch(setActiveTab(index))}
+            ref={(r) => {
+              ref.current = r;
+              draggableProvided.innerRef(r);
+            }}
+            {...draggableProvided.draggableProps}
+            {...draggableProvided.dragHandleProps}
+            style={getDraggableStyle(draggableProvided.draggableProps.style as DraggingStyle)}
+            onMouseUp={handleMouseUp}
+          >
+            <S.TabNameWrapper>{tabName}</S.TabNameWrapper>
+            <Button
+              type="text"
+              size="small"
+              icon={<CloseOutlined style={{ fontSize: '12px', color: theme.text }} />}
+              onClick={handleOnClick}
+            />
+          </S.DraggableTabWrapper>
+        )}
+      </Draggable>
+    </Suspense>
   );
 };
 

--- a/frontend/src/components/DraggableTab/DraggableTab.tsx
+++ b/frontend/src/components/DraggableTab/DraggableTab.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 import type { DraggingStyle } from 'react-beautiful-dnd';
-import { Draggable } from 'react-beautiful-dnd';
 import { useDispatch, useSelector } from 'react-redux';
 import { CloseOutlined } from '@ant-design/icons';
 import { Button } from 'antd';
@@ -9,6 +8,8 @@ import type { RootState } from 'config/store';
 import useIntersectionObserver from 'hooks/useIntersectionObserver';
 import { removeTab, setActiveTab } from 'reducers/courseTabsSlice';
 import S from './styles';
+
+const Draggable = React.lazy(() => import('react-beautiful-dnd').then((plot) => ({ default: plot.Draggable })));
 
 type Props = {
   tabName: string

--- a/frontend/src/components/LiquidProgressChart/LiquidProgressChart.tsx
+++ b/frontend/src/components/LiquidProgressChart/LiquidProgressChart.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
-import type { LiquidConfig } from '@ant-design/charts';
-import { Liquid } from '@ant-design/charts';
+import type { LiquidConfig } from '@ant-design/plots';
 import {
   darkGrey,
   lightGrey,
@@ -16,6 +15,8 @@ type Props = {
   completedUOC: number
   totalUOC: number
 };
+
+const Liquid = React.lazy(() => import('@ant-design/plots').then((plot) => ({ default: plot.Liquid })));
 
 const LiquidProgressChart = ({ completedUOC, totalUOC }: Props) => {
   const [percent, setPercent] = useState(0);
@@ -86,7 +87,9 @@ const LiquidProgressChart = ({ completedUOC, totalUOC }: Props) => {
         {completedUOC} / {totalUOC} UOC
       </ReactTooltip>
       <div data-tip>
-        <Liquid {...config} />
+        <Suspense fallback={<div>Loading...</div>}>
+          <Liquid {...config} />
+        </Suspense>
       </div>
     </div>
   );

--- a/frontend/src/components/PrerequisiteTree/PrerequisiteTree.tsx
+++ b/frontend/src/components/PrerequisiteTree/PrerequisiteTree.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { Item, TreeGraph, TreeGraphData } from '@antv/g6';
-import G6 from '@antv/g6';
 import axios from 'axios';
 import { CourseChildren, CoursePathFrom, CoursesAllUnlocked } from 'types/api';
 import { CourseList } from 'types/courses';
@@ -35,11 +34,12 @@ const PrerequisiteTree = ({ courseCode }: Props) => {
 
   useEffect(() => {
     /* GRAPH IMPLEMENTATION */
-    const generateTreeGraph = (graphData: TreeGraphData) => {
+    const generateTreeGraph = async (graphData: TreeGraphData) => {
       const container = ref.current;
       if (!container) return;
+      const { TreeGraph } = await import('@antv/g6');
 
-      const treeGraphInstance = new G6.TreeGraph({
+      const treeGraphInstance = new TreeGraph({
         container,
         width: container.scrollWidth,
         height: container.scrollHeight,

--- a/frontend/src/components/RadialBarChart/RadialBarChart.tsx
+++ b/frontend/src/components/RadialBarChart/RadialBarChart.tsx
@@ -3,10 +3,11 @@
 
 // TODO: fix typescript eslint here
 
-import React from 'react';
-import type { RadialBarConfig } from '@ant-design/charts';
-import { RadialBar } from '@ant-design/charts';
+import React, { Suspense } from 'react';
+import type { RadialBarConfig } from '@ant-design/plots';
 import data from './radialChartData';
+
+const RadialBar = React.lazy(() => import('@ant-design/plots').then((plot) => ({ default: plot.RadialBar })));
 
 const RadialBarChart = () => {
   const config: RadialBarConfig = {
@@ -30,7 +31,11 @@ const RadialBarChart = () => {
     barBackground: {},
     barStyle: { lineCap: 'round' },
   };
-  return <RadialBar {...config} />;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <RadialBar {...config} />
+    </Suspense>
+  );
 };
 
 export default RadialBarChart;

--- a/frontend/src/pages/CourseSelector/CourseTabs/CourseTabs.tsx
+++ b/frontend/src/pages/CourseSelector/CourseTabs/CourseTabs.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import type { OnDragEndResponder, OnDragStartResponder } from 'react-beautiful-dnd';
-import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import { useDispatch, useSelector } from 'react-redux';
 import { DeleteOutlined } from '@ant-design/icons';
 import { Popconfirm, Switch, Tooltip } from 'antd';
@@ -9,6 +8,9 @@ import type { RootState } from 'config/store';
 import { reorderTabs, resetTabs, setActiveTab } from 'reducers/courseTabsSlice';
 import { toggleLockedCourses } from 'reducers/settingsSlice';
 import S from './styles';
+
+const DragDropContext = React.lazy(() => import('react-beautiful-dnd').then((plot) => ({ default: plot.DragDropContext })));
+const Droppable = React.lazy(() => import('react-beautiful-dnd').then((plot) => ({ default: plot.Droppable })));
 
 const CourseTabs = () => {
   const dispatch = useDispatch();

--- a/frontend/src/pages/CourseSelector/CourseTabs/CourseTabs.tsx
+++ b/frontend/src/pages/CourseSelector/CourseTabs/CourseTabs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import type { OnDragEndResponder, OnDragStartResponder } from 'react-beautiful-dnd';
 import { useDispatch, useSelector } from 'react-redux';
 import { DeleteOutlined } from '@ant-design/icons';
@@ -48,21 +48,23 @@ const CourseTabs = () => {
           onChange={() => dispatch(toggleLockedCourses())}
         />
       </S.ShowAllCourses>
-      <DragDropContext onDragEnd={handleOnDragEnd} onDragStart={handleOnDragStart}>
-        <Droppable droppableId="droppable" direction="horizontal">
-          {(droppableProvided) => (
-            <S.CourseTabsSection
-              ref={droppableProvided.innerRef}
-              {...droppableProvided.droppableProps}
-            >
-              {tabs.map((tab, index) => (
-                <DraggableTab tabName={tab} index={index} />
-              ))}
-              {droppableProvided.placeholder}
-            </S.CourseTabsSection>
-          )}
-        </Droppable>
-      </DragDropContext>
+      <Suspense fallback={<div>Loading...</div>}>
+        <DragDropContext onDragEnd={handleOnDragEnd} onDragStart={handleOnDragStart}>
+          <Droppable droppableId="droppable" direction="horizontal">
+            {(droppableProvided) => (
+              <S.CourseTabsSection
+                ref={droppableProvided.innerRef}
+                {...droppableProvided.droppableProps}
+              >
+                {tabs.map((tab, index) => (
+                  <DraggableTab tabName={tab} index={index} />
+                ))}
+                {droppableProvided.placeholder}
+              </S.CourseTabsSection>
+            )}
+          </Droppable>
+        </DragDropContext>
+      </Suspense>
       {
         !!tabs.length
         && (

--- a/frontend/src/pages/GraphicalSelector/GraphicalSelector.tsx
+++ b/frontend/src/pages/GraphicalSelector/GraphicalSelector.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { LockOutlined, UnlockOutlined } from '@ant-design/icons';
-import { breadthFirstSearch } from '@antv/algorithm';
 import type { Graph, INode, Item } from '@antv/g6';
-import G6 from '@antv/g6';
 import { Button, Switch, Tooltip } from 'antd';
 import axios from 'axios';
 import {
@@ -42,11 +40,12 @@ const GraphicalSelector = () => {
 
   useEffect(() => {
     // courses is a list of course codes
-    const initialiseGraph = (courses: string[], courseEdges: CourseEdge[]) => {
+    const initialiseGraph = async (courses: string[], courseEdges: CourseEdge[]) => {
       const container = ref.current;
       if (!container) return;
-
-      const graphInstance = new G6.Graph({
+      const { Graph, Arrow } = await import('@antv/g6');
+      const { breadthFirstSearch } = await import('@antv/algorithm');
+      const graphInstance = new Graph({
         container,
         width: container.scrollWidth,
         height: container.scrollHeight,
@@ -66,7 +65,7 @@ const GraphicalSelector = () => {
         },
         // animate: true,
         defaultNode: GRAPH_STYLE.defaultNode,
-        defaultEdge: GRAPH_STYLE.defaultEdge,
+        defaultEdge: GRAPH_STYLE.defaultEdge(Arrow),
         nodeStateStyles: GRAPH_STYLE.nodeStateStyles,
       });
 

--- a/frontend/src/pages/GraphicalSelector/config.ts
+++ b/frontend/src/pages/GraphicalSelector/config.ts
@@ -1,4 +1,4 @@
-import G6 from '@antv/g6';
+import type { Arrow } from '@antv/g6';
 
 const defaultNode = {
   size: 70,
@@ -16,15 +16,15 @@ const defaultNode = {
   },
 };
 
-const defaultEdge = {
+const defaultEdge = (arrow: typeof Arrow) => ({
   style: {
     endArrow: {
-      path: G6.Arrow.triangle(5, 5, 30),
+      path: arrow.triangle(5, 5, 30),
       fill: '#e0e0e0',
       d: 25,
     },
   },
-};
+});
 
 const nodeStateStyles = {
   hover: {

--- a/frontend/src/pages/TermPlanner/DraggableCourse/DraggableCourse.tsx
+++ b/frontend/src/pages/TermPlanner/DraggableCourse/DraggableCourse.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { useContextMenu } from 'react-contexify';
 import { useSelector } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
@@ -56,65 +56,66 @@ const DraggableCourse = ({ code, index, term }: Props) => {
 
   return (
     <>
-      <Draggable
-        isDragDisabled={isDragDisabled}
-        draggableId={`${code}${term}`}
-        index={index}
-      >
-        {(provided) => (
-          <S.CourseWrapper
-            summerEnabled={isSummerEnabled}
-            isSmall={isSmall}
-            dragDisabled={isDragDisabled}
-            warningsDisabled={isDragDisabled && !isUnlocked}
-            isWarning={!supressed && (!isUnlocked || !isOffered)}
-            {...provided.draggableProps}
-            {...provided.dragHandleProps}
-            ref={provided.innerRef}
-            style={provided.draggableProps.style}
-            data-tip
-            data-for={code}
-            id={code}
-            onContextMenu={handleContextMenu}
-          >
-            {!isDragDisabled && shouldHaveWarning
-              && (errorIsInformational ? (
-                <InfoCircleOutlined
-                  style={{ color: theme.infoOutlined.color }}
-                />
-              ) : (
-                <WarningOutlined
-                  style={{ fontSize: '16px', color: theme.warningOutlined.color }}
-                />
-              ))}
-            <S.CourseLabel>
-              {isSmall ? (
-                <Text className="text">{code}</Text>
-              ) : (
-                <div>
-                  <Text className="text">
-                    <strong>{code}: </strong>
-                    {title}
-                  </Text>
-                </div>
-              )}
-              {showMarks && (
-                <div>
-                  <Text strong className="text">Mark: </Text>
-                  <Text className="text">
-                    {/*
+      <Suspense fallback={<div>Loading...</div>}>
+        <Draggable
+          isDragDisabled={isDragDisabled}
+          draggableId={`${code}${term}`}
+          index={index}
+        >
+          {(provided) => (
+            <S.CourseWrapper
+              summerEnabled={isSummerEnabled}
+              isSmall={isSmall}
+              dragDisabled={isDragDisabled}
+              warningsDisabled={isDragDisabled && !isUnlocked}
+              isWarning={!supressed && (!isUnlocked || !isOffered)}
+              {...provided.draggableProps}
+              {...provided.dragHandleProps}
+              ref={provided.innerRef}
+              style={provided.draggableProps.style}
+              data-tip
+              data-for={code}
+              id={code}
+              onContextMenu={handleContextMenu}
+            >
+              {!isDragDisabled && shouldHaveWarning
+                && (errorIsInformational ? (
+                  <InfoCircleOutlined
+                    style={{ color: theme.infoOutlined.color }}
+                  />
+                ) : (
+                  <WarningOutlined
+                    style={{ fontSize: '16px', color: theme.warningOutlined.color }}
+                  />
+                ))}
+              <S.CourseLabel>
+                {isSmall ? (
+                  <Text className="text">{code}</Text>
+                ) : (
+                  <div>
+                    <Text className="text">
+                      <strong>{code}: </strong>
+                      {title}
+                    </Text>
+                  </div>
+                )}
+                {showMarks && (
+                  <div>
+                    <Text strong className="text">Mark: </Text>
+                    <Text className="text">
+                      {/*
                       Marks can be strings (i.e. HD, CR) or a number (i.e. 90, 85).
                       Mark can be 0.
                     */}
-                    {typeof mark === 'string' || typeof mark === 'number' ? mark : 'N/A'}
-                  </Text>
-                </div>
-              )}
-            </S.CourseLabel>
-          </S.CourseWrapper>
-        )}
-      </Draggable>
-      <ContextMenu code={code} plannedFor={plannedFor} />
+                      {typeof mark === 'string' || typeof mark === 'number' ? mark : 'N/A'}
+                    </Text>
+                  </div>
+                )}
+              </S.CourseLabel>
+            </S.CourseWrapper>
+          )}
+        </Draggable>
+      </Suspense><ContextMenu code={code} plannedFor={plannedFor} />
       {/* display prereq tooltip for all courses. However, if a term is marked as complete
         and the course has no warning, then disable the tooltip */}
       {isSmall && (

--- a/frontend/src/pages/TermPlanner/DraggableCourse/DraggableCourse.tsx
+++ b/frontend/src/pages/TermPlanner/DraggableCourse/DraggableCourse.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Draggable } from 'react-beautiful-dnd';
 import { useContextMenu } from 'react-contexify';
 import { useSelector } from 'react-redux';
 import ReactTooltip from 'react-tooltip';
@@ -16,6 +15,8 @@ type Props = {
   index: number
   term: string
 };
+
+const Draggable = React.lazy(() => import('react-beautiful-dnd').then((plot) => ({ default: plot.Draggable })));
 
 const DraggableCourse = ({ code, index, term }: Props) => {
   const {

--- a/frontend/src/pages/TermPlanner/ExportPlannerMenu/ExportPlannerMenu.tsx
+++ b/frontend/src/pages/TermPlanner/ExportPlannerMenu/ExportPlannerMenu.tsx
@@ -1,8 +1,4 @@
 import React, { useState } from 'react';
-import {
-  exportComponentAsJPEG,
-  exportComponentAsPNG,
-} from 'react-component-export-image';
 import { Button, Radio } from 'antd';
 import CS from '../common/styles';
 import S from './styles';
@@ -17,7 +13,8 @@ const ExportPlannerMenu = ({ plannerRef }: Props) => {
 
   const [format, setFormat] = useState('png');
 
-  const download = () => {
+  const download = async () => {
+    const { exportComponentAsJPEG, exportComponentAsPNG } = await import('react-component-export-image');
     if (format === 'png') {
       exportComponentAsPNG(plannerRef, exportFields);
     } else if (format === 'jpg') {

--- a/frontend/src/pages/TermPlanner/TermBox/TermBox.tsx
+++ b/frontend/src/pages/TermPlanner/TermBox/TermBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { LockFilled, UnlockFilled } from '@ant-design/icons';
 import { Badge } from 'antd';
@@ -59,59 +59,61 @@ const TermBox = ({
     boxShadow: 'none',
   };
   return (
-    <Droppable droppableId={name} isDropDisabled={isCompleted}>
-      {(provided) => (
-        <Badge
-          count={(
-            <S.TermCheckboxWrapper checked={isCompleted}>
-              {(
-                  !isCompleted
-                    ? (
-                      <UnlockFilled
-                        style={iconStyle}
-                        onClick={handleCompleteTerm}
-                      />
-                    ) : (
-                      <LockFilled
-                        style={iconStyle}
-                        onClick={handleCompleteTerm}
-                      />
-                    ) //
-                )}
-            </S.TermCheckboxWrapper>
-            )}
-          offset={isSummerEnabled ? [-13, 13] : [-22, 22]}
-        >
-          <S.TermBoxWrapper
-            droppable={isOffered && dragging}
-            summerEnabled={isSummerEnabled}
-            isSmall={isSmall}
-            ref={provided.innerRef}
-            {...provided.droppableProps}
+    <Suspense fallback={<div>Loading...</div>}>
+      <Droppable droppableId={name} isDropDisabled={isCompleted}>
+        {(provided) => (
+          <Badge
+            count={(
+              <S.TermCheckboxWrapper checked={isCompleted}>
+                {(
+                    !isCompleted
+                      ? (
+                        <UnlockFilled
+                          style={iconStyle}
+                          onClick={handleCompleteTerm}
+                        />
+                      ) : (
+                        <LockFilled
+                          style={iconStyle}
+                          onClick={handleCompleteTerm}
+                        />
+                      ) //
+                  )}
+              </S.TermCheckboxWrapper>
+              )}
+            offset={isSummerEnabled ? [-13, 13] : [-22, 22]}
           >
-            {coursesList.map(
-              (code, index) => (
-                <DraggableCourse
-                  key={`${code}${term}`}
-                  code={code}
-                  index={index}
-                  term={term}
+            <S.TermBoxWrapper
+              droppable={isOffered && dragging}
+              summerEnabled={isSummerEnabled}
+              isSmall={isSmall}
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+            >
+              {coursesList.map(
+                (code, index) => (
+                  <DraggableCourse
+                    key={`${code}${term}`}
+                    code={code}
+                    index={index}
+                    term={term}
+                  />
+                ),
+              )}
+              {provided.placeholder}
+              <S.UOCBadgeWrapper>
+                <Badge
+                  style={uocBadgeStyle}
+                  size="small"
+                  count={`${totalUOC} UOC`}
+                  offset={[0, 0]}
                 />
-              ),
-            )}
-            {provided.placeholder}
-            <S.UOCBadgeWrapper>
-              <Badge
-                style={uocBadgeStyle}
-                size="small"
-                count={`${totalUOC} UOC`}
-                offset={[0, 0]}
-              />
-            </S.UOCBadgeWrapper>
-          </S.TermBoxWrapper>
-        </Badge>
-      )}
-    </Droppable>
+              </S.UOCBadgeWrapper>
+            </S.TermBoxWrapper>
+          </Badge>
+        )}
+      </Droppable>
+    </Suspense>
   );
 };
 

--- a/frontend/src/pages/TermPlanner/TermBox/TermBox.tsx
+++ b/frontend/src/pages/TermPlanner/TermBox/TermBox.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Droppable } from 'react-beautiful-dnd';
 import { useDispatch, useSelector } from 'react-redux';
 import { LockFilled, UnlockFilled } from '@ant-design/icons';
 import { Badge } from 'antd';
@@ -9,6 +8,8 @@ import useMediaQuery from 'hooks/useMediaQuery';
 import { toggleTermComplete } from 'reducers/plannerSlice';
 import DraggableCourse from '../DraggableCourse';
 import S from './styles';
+
+const Droppable = React.lazy(() => import('react-beautiful-dnd').then((plot) => ({ default: plot.Droppable })));
 
 type Props = {
   name: string

--- a/frontend/src/pages/TermPlanner/TermPlanner.tsx
+++ b/frontend/src/pages/TermPlanner/TermPlanner.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
 import type { OnDragEndResponder, OnDragStartResponder } from 'react-beautiful-dnd';
-import { DragDropContext } from 'react-beautiful-dnd';
 import { useDispatch, useSelector } from 'react-redux';
 import { Badge } from 'antd';
 import axios from 'axios';
@@ -23,6 +22,8 @@ import {
   checkMultitermInBounds,
   isPlannerEmpty,
 } from './utils';
+
+const DragDropContext = React.lazy(() => import('react-beautiful-dnd').then((plot) => ({ default: plot.DragDropContext })));
 
 const TermPlanner = () => {
   const { showWarnings } = useSelector((state: RootState) => state.settings);

--- a/frontend/src/pages/TermPlanner/TermPlanner.tsx
+++ b/frontend/src/pages/TermPlanner/TermPlanner.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  Suspense, useEffect, useRef, useState,
+} from 'react';
 import type { OnDragEndResponder, OnDragStartResponder } from 'react-beautiful-dnd';
 import { useDispatch, useSelector } from 'react-redux';
 import { Badge } from 'antd';
@@ -169,69 +171,71 @@ const TermPlanner = () => {
         plannerRef={plannerPicRef}
       />
       <S.ContainerWrapper>
-        <DragDropContext
-          onDragEnd={handleOnDragEnd}
-          onDragStart={handleOnDragStart}
-        >
-          <S.PlannerContainer>
-            <S.PlannerGridWrapper
-              summerEnabled={planner.isSummerEnabled}
-              ref={plannerPicRef}
-            >
-              <GridItem /> {/* Empty grid item for the year */}
-              {planner.isSummerEnabled && <GridItem>Summer</GridItem>}
-              <GridItem>Term 1</GridItem>
-              <GridItem>Term 2</GridItem>
-              <GridItem>Term 3</GridItem>
-              {planner.years.map((year, index) => {
-                const iYear = planner.startYear + index;
-                let yearUOC = 0;
-                Object.keys(year).forEach((termKey) => {
-                  Object.keys(planner.courses).forEach((courseCode) => {
-                    if (year[termKey as Term].includes(courseCode)) {
-                      yearUOC += planner.courses[courseCode].UOC;
-                    }
+        <Suspense fallback={<div>Loading...</div>}>
+          <DragDropContext
+            onDragEnd={handleOnDragEnd}
+            onDragStart={handleOnDragStart}
+          >
+            <S.PlannerContainer>
+              <S.PlannerGridWrapper
+                summerEnabled={planner.isSummerEnabled}
+                ref={plannerPicRef}
+              >
+                <GridItem /> {/* Empty grid item for the year */}
+                {planner.isSummerEnabled && <GridItem>Summer</GridItem>}
+                <GridItem>Term 1</GridItem>
+                <GridItem>Term 2</GridItem>
+                <GridItem>Term 3</GridItem>
+                {planner.years.map((year, index) => {
+                  const iYear = planner.startYear + index;
+                  let yearUOC = 0;
+                  Object.keys(year).forEach((termKey) => {
+                    Object.keys(planner.courses).forEach((courseCode) => {
+                      if (year[termKey as Term].includes(courseCode)) {
+                        yearUOC += planner.courses[courseCode].UOC;
+                      }
+                    });
                   });
-                });
-                if (planner.hidden[iYear]) return null;
-                return (
-                  <React.Fragment key={iYear}>
-                    <S.YearGridBox>
-                      <S.YearWrapper>
-                        <S.YearText currYear={currYear === iYear}>
-                          {iYear}
-                        </S.YearText>
-                        <HideYearTooltip year={iYear} />
-                      </S.YearWrapper>
-                      <Badge
-                        style={{
-                          backgroundColor: '#efdbff',
-                          color: '#000000',
-                        }}
-                        size="small"
-                        count={`${yearUOC} UOC`}
-                      />
-                    </S.YearGridBox>
-                    {Object.keys(year).map((term) => {
-                      const key = `${iYear}${term}`;
-                      if (!planner.isSummerEnabled && term === 'T0') return null;
-                      return (
-                        <TermBox
-                          key={key}
-                          name={key}
-                          coursesList={year[term as Term]}
-                          termsOffered={termsOffered}
-                          dragging={isDragging}
+                  if (planner.hidden[iYear]) return null;
+                  return (
+                    <React.Fragment key={iYear}>
+                      <S.YearGridBox>
+                        <S.YearWrapper>
+                          <S.YearText currYear={currYear === iYear}>
+                            {iYear}
+                          </S.YearText>
+                          <HideYearTooltip year={iYear} />
+                        </S.YearWrapper>
+                        <Badge
+                          style={{
+                            backgroundColor: '#efdbff',
+                            color: '#000000',
+                          }}
+                          size="small"
+                          count={`${yearUOC} UOC`}
                         />
-                      );
-                    })}
-                  </React.Fragment>
-                );
-              })}
-              <UnplannedColumn dragging={isDragging} />
-            </S.PlannerGridWrapper>
-          </S.PlannerContainer>
-        </DragDropContext>
+                      </S.YearGridBox>
+                      {Object.keys(year).map((term) => {
+                        const key = `${iYear}${term}`;
+                        if (!planner.isSummerEnabled && term === 'T0') return null;
+                        return (
+                          <TermBox
+                            key={key}
+                            name={key}
+                            coursesList={year[term as Term]}
+                            termsOffered={termsOffered}
+                            dragging={isDragging}
+                          />
+                        );
+                      })}
+                    </React.Fragment>
+                  );
+                })}
+                <UnplannedColumn dragging={isDragging} />
+              </S.PlannerGridWrapper>
+            </S.PlannerContainer>
+          </DragDropContext>
+        </Suspense>
       </S.ContainerWrapper>
     </PageTemplate>
   );

--- a/frontend/src/pages/TermPlanner/UnplannedColumn/UnplannedColumn.tsx
+++ b/frontend/src/pages/TermPlanner/UnplannedColumn/UnplannedColumn.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { useSelector } from 'react-redux';
 import type { RootState } from 'config/store';
 import useMediaQuery from 'hooks/useMediaQuery';
@@ -18,27 +18,29 @@ const UnplannedColumn = ({ dragging }: Props) => {
   return (
     <S.UnplannedContainer summerEnabled={isSummerEnabled}>
       <S.UnplannedTitle>Unplanned</S.UnplannedTitle>
-      <Droppable droppableId="unplanned">
-        {(provided) => (
-          <S.UnplannedBox
-            ref={provided.innerRef}
-            {...provided.droppableProps}
-            summerEnabled={isSummerEnabled}
-            droppable={dragging}
-            isSmall={isSmall}
-          >
-            {unplanned.map((course, courseIndex) => (
-              <DraggableCourse
-                code={course}
-                index={courseIndex}
-                key={course}
-                term=""
-              />
-            ))}
-            {provided.placeholder}
-          </S.UnplannedBox>
-        )}
-      </Droppable>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Droppable droppableId="unplanned">
+          {(provided) => (
+            <S.UnplannedBox
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              summerEnabled={isSummerEnabled}
+              droppable={dragging}
+              isSmall={isSmall}
+            >
+              {unplanned.map((course, courseIndex) => (
+                <DraggableCourse
+                  code={course}
+                  index={courseIndex}
+                  key={course}
+                  term=""
+                />
+              ))}
+              {provided.placeholder}
+            </S.UnplannedBox>
+          )}
+        </Droppable>
+      </Suspense>
     </S.UnplannedContainer>
   );
 };

--- a/frontend/src/pages/TermPlanner/UnplannedColumn/UnplannedColumn.tsx
+++ b/frontend/src/pages/TermPlanner/UnplannedColumn/UnplannedColumn.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Droppable } from 'react-beautiful-dnd';
 import { useSelector } from 'react-redux';
 import type { RootState } from 'config/store';
 import useMediaQuery from 'hooks/useMediaQuery';
@@ -9,6 +8,8 @@ import S from './styles';
 type Props = {
   dragging: boolean
 };
+
+const Droppable = React.lazy(() => import('react-beautiful-dnd').then((plot) => ({ default: plot.Droppable })));
 
 const UnplannedColumn = ({ dragging }: Props) => {
   const { isSummerEnabled, unplanned } = useSelector((state: RootState) => state.planner);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import { resolve } from "path";
 import { defineConfig } from "vite";
 import eslint from "vite-plugin-eslint";
 import svgrPlugin from "vite-plugin-svgr";
+import { visualizer } from "rollup-plugin-visualizer";
 
 const projectRootDir = resolve(__dirname);
 
@@ -24,7 +25,7 @@ export default defineConfig({
         // ...svgr options (https://react-svgr.com/docs/options/)
       },
     }),
-    eslint(),
+    eslint()
   ],
   resolve: {
     alias: [


### PR DESCRIPTION
This PR has to be reopened because there was a critical oversight in the previous PR, and it had to be unmerged.

The thing I missed in my previous review was that all lazy-loaded components **must have a fallback state**, which some were missing, leading to runtime panics in production.

@Peedee2002 please add these missing fallback states as part of your previous PR; we can merge after.