### PR TITLE
Feat/circles 362/terms available route

### DIFF
--- a/backend/server/routers/courses.py
+++ b/backend/server/routers/courses.py
@@ -446,8 +446,26 @@ def courses_unlocked_when_taken(userData: UserData, courseToBeTaken: str) -> Dic
     }
 
 
-@router.get("/termsOffered/{course}", response_model=TermsList)
-def terms_offered(course: str) -> List[str]:
+@router.get(
+    "/termsOffered/{course}",
+    response_model=TermsList,
+    responses={
+        400: {
+            "description": "The given course code could not be found in the database",
+        },
+        200: {
+            "description": "Returns the terms a course is offered in",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "terms": ["21T2", "21T2", "21T3"],
+                    },
+                },
+            },
+        },
+    }
+)
+def terms_offered(course: str) -> Dict[str, List[str]]:
     """
     Returns a list of terms in which the given course is offered.
     The list of terms is only relevant for the LIVE_YEAR and may
@@ -458,13 +476,29 @@ def terms_offered(course: str) -> List[str]:
         "terms": get_course(course).get("terms", []),
     }
 
-@router.get("/legacyTermsOffered/{year}/{course}", response_model=TermsList)
-def legacy_terms_offered(course: str) -> List[str]:
+@router.get(
+    "/legacyTermsOffered/{year}/{course}",
+    response_model=TermsList,
+    responses={
+        400: {"description": "Year or Term input is incorrect"},
+        200: {
+            "description": "Returns the program structure",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "terms": ["21T2", "21T2", "21T3"],
+                    }
+                }
+            },
+        },
+    }
+)
+def legacy_terms_offered(year, course: str="") -> Dict[str, List[str]]:
     """
     Equivalent to `/termsOffered` but for legacy courses.
     """
     return {
-        "terms": get_legacy_course(course).get("terms", []),
+        "terms": get_legacy_course(year, course).get("terms", []),
     }
 
 

--- a/backend/server/routers/model.py
+++ b/backend/server/routers/model.py
@@ -37,7 +37,7 @@ class CourseDetails(BaseModel):
     gen_ed: bool
     is_legacy: bool
     is_accurate: bool
-    is_multiterm: bool
+    is_multiterm: Optional[bool]
 
 
 class ContainerContent(TypedDict):
@@ -177,6 +177,9 @@ class Graph(BaseModel):
     courses: list[str]
     # tuple is of type (str, fastapi.exceptions.HTTPException)
     err_edges: list[tuple]
+
+class TermsList(BaseModel):
+    terms: list[str]
 
 
 


### PR DESCRIPTION
## Route
- Add routes `courses/termsOffered/{course}` and `courses/legacyTermsOffered/{year}/{course}`
- Both will return list of courses that are offered. Used same as `/getCourse` and the corresponding legacy route.

## Bug (maybe)
- Some instances of `/courses/getCourse` were failing because the returned object didn't have a `multiterm` attribute as required by the response model. Moved this as an optional setting for now since if it's not `true` as it shouldn't affect the courses that are *actually* multi-term right now. Not sure if just a matter of re-running processors to update course info or, adding in a clause to the processors to add in that multi-term aspect. Worth looking at in future card.