### PR TITLE
feat(backend) Expand `ProgramRestriction` classes [CIRCLES-364]

### DIFF
--- a/backend/algorithms/objects/program_restrictions.py
+++ b/backend/algorithms/objects/program_restrictions.py
@@ -69,6 +69,7 @@ class CompositeRestriction(ProgramRestriction):
                 raise ValueError(f"Unknown logic: {self.logic}")
 
     def set_logic(self, logic: Logic):
+        """ Set the logic of the composite restriction"""
         self.logic = logic
 
     def add_category(self, category: Category):
@@ -95,6 +96,7 @@ class MaturityRestriction(ProgramRestriction):
         return self.dependent.match_definition(course)
 
     def dependency_met(self, user: User) -> bool:
+        """ Wrapper to validate `dependency` as just a boolean """
         return self.dependency.validate(user)[0]
 
     def validate_course_allowed(
@@ -127,7 +129,6 @@ class CourseRestriction(ProgramRestriction):
         self.course = course
 
     def validate_course_allowed(self, user: User, course: str) -> bool:
-        user # prevent unused variable warning but keep ABC satisfied
         return course != self.course
 
     def __str__(self) -> str:

--- a/backend/algorithms/objects/program_restrictions.py
+++ b/backend/algorithms/objects/program_restrictions.py
@@ -72,9 +72,9 @@ class CompositeRestriction(ProgramRestriction):
         """ Set the logic of the composite restriction"""
         self.logic = logic
 
-    def add_category(self, category: Category):
+    def add_restriction(self, restriction: ProgramRestriction):
         """Add an aditional category to the composite restriction"""
-        self.restrictions.append(category)
+        self.restrictions.append(restriction)
 
     def __str__(self) -> str:
         return f"CompositeRestriction({self.restrictions})"
@@ -141,7 +141,7 @@ class CategoryUOCRestriction(ProgramRestriction):
     """
 
     def __init__(self, uoc: int, category: Category) -> None:
-        self.category: int = category
+        self.category: Category = category
         self.uoc_allowed: int = uoc
 
     def validate_course_allowed(self, user: User, course: str, course_uoc: int=6) -> bool:
@@ -150,7 +150,7 @@ class CategoryUOCRestriction(ProgramRestriction):
             - Course matches the category
             - User has already done max uoc of the category
         """
-        if not self.ctegory.match_definition(course):
+        if not self.category.match_definition(course):
             return True
         uoc_completed: int = sum(
             uoc for _, uoc in user.get_courses_with_uoc()

--- a/backend/algorithms/objects/user.py
+++ b/backend/algorithms/objects/user.py
@@ -8,7 +8,7 @@
 import copy
 from itertools import chain
 import json
-from typing import Literal, Optional, Tuple
+from typing import List, Literal, Optional, Tuple
 import re
 from algorithms.cache.cache_config import CACHED_EQUIVALENTS_FILE, CACHED_EXCLUSIONS_FILE
 from algorithms.objects.categories import AnyCategory, Category
@@ -92,6 +92,12 @@ class User:
     def get_courses(self):
         """ get all course codes """
         return list(self.courses.keys())
+
+    def get_courses_with_uoc(self) -> List[Tuple[str, int]]:
+        return [
+            (course, uoc)
+            for course, (uoc, _) in self.courses.items()
+        ]
 
     def in_specialisation(self, specialisation: str):
         """ Determines if the user is in the specialisation """


### PR DESCRIPTION
Contains the following classes:
- `CompositeRestriction`
- `CategoryRestriction`
- `CategoryUOCRestriction`
- `CourseRestriction`

I was hesitant to write these initially because these are unused and won't be built since the pre-processing / tokenising for these types of conditions hasn't happened yet. But
- I was bored and this seemed like less work than the processors
- It should be fine to merge these in since their structure is pretty uniform wrt to the other Restrictions and should be agnostic of what the processors are doing anyways.
