### PR TITLE
feat: configure landing page routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,13 +35,10 @@ const App = () => {
               <Route
                 path="/"
                 element={
-                  <Navigate
-                    to={!degree.isComplete ? '/degree-wizard' : '/course-selector'}
-                    replace
-                  />
+                  !degree.isComplete ? <LandingPage /> : <Navigate to="/course-selector" replace />
                 }
               />
-              <Route path="/landing-page" element={<LandingPage />} />
+              <Route path="/" element={<LandingPage />} />
               <Route path="/degree-wizard" element={<DegreeWizard />} />
               <Route path="/course-selector" element={<CourseSelector />} />
               {inDev && <Route path="/graphical-selector" element={<GraphicalSelector />} />}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,6 @@ const App = () => {
                   !degree.isComplete ? <LandingPage /> : <Navigate to="/course-selector" replace />
                 }
               />
-              <Route path="/" element={<LandingPage />} />
               <Route path="/degree-wizard" element={<DegreeWizard />} />
               <Route path="/course-selector" element={<CourseSelector />} />
               {inDev && <Route path="/graphical-selector" element={<GraphicalSelector />} />}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,12 +7,12 @@ import PageLoading from 'components/PageLoading';
 import { inDev } from 'config/constants';
 import type { RootState } from 'config/store';
 import { darkTheme, GlobalStyles, lightTheme } from 'config/theme';
-import LandingPage from 'pages/LandingPage';
 import './config/axios';
 // stylesheets for antd library
 import 'antd/dist/antd.less';
 
 // Lazy load in pages
+const LandingPage = React.lazy(() => import('./pages/LandingPage'));
 const CourseSelector = React.lazy(() => import('./pages/CourseSelector'));
 const DegreeWizard = React.lazy(() => import('./pages/DegreeWizard'));
 const GraphicalSelector = React.lazy(() => import('./pages/GraphicalSelector'));

--- a/frontend/src/components/PageTemplate/PageTemplate.tsx
+++ b/frontend/src/components/PageTemplate/PageTemplate.tsx
@@ -1,26 +1,36 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
+import { useSelector } from 'react-redux';
+import { Navigate, useLocation } from 'react-router-dom';
 import FeedbackButton from 'components/FeedbackButton';
 import Header from 'components/Header';
+import { RootState } from 'config/store';
 
 type Props = {
   children: React.ReactNode;
   showHeader?: boolean;
 };
 
-const PageTemplate = ({ children, showHeader = true }: Props) => (
-  <>
-    <Helmet>
-      <title>Circles</title>
-      <meta name="description" content="Circles UNSW Degree Planner" />
-      <meta name="keywords" content="circles, unsw, csesoc, degree, planner, course, plan" />
-    </Helmet>
-    {showHeader && <Header />}
-    <div>
-      {children}
-      <FeedbackButton />
-    </div>
-  </>
-);
+const PageTemplate = ({ children, showHeader = true }: Props) => {
+  const { pathname } = useLocation();
+  const degree = useSelector((state: RootState) => state.degree);
+
+  if (!degree.isComplete && pathname !== '/degree-wizard') return <Navigate to="/" replace />;
+
+  return (
+    <>
+      <Helmet>
+        <title>Circles</title>
+        <meta name="description" content="Circles UNSW Degree Planner" />
+        <meta name="keywords" content="circles, unsw, csesoc, degree, planner, course, plan" />
+      </Helmet>
+      {showHeader && <Header />}
+      <div>
+        {children}
+        <FeedbackButton />
+      </div>
+    </>
+  );
+};
 
 export default PageTemplate;

--- a/frontend/src/components/PageTemplate/PageTemplate.tsx
+++ b/frontend/src/components/PageTemplate/PageTemplate.tsx
@@ -1,36 +1,26 @@
 import React from 'react';
 import { Helmet } from 'react-helmet';
-import { useSelector } from 'react-redux';
-import { Navigate, useLocation } from 'react-router-dom';
 import FeedbackButton from 'components/FeedbackButton';
 import Header from 'components/Header';
-import { RootState } from 'config/store';
 
 type Props = {
   children: React.ReactNode;
   showHeader?: boolean;
 };
 
-const PageTemplate = ({ children, showHeader = true }: Props) => {
-  const { pathname } = useLocation();
-  const degree = useSelector((state: RootState) => state.degree);
-
-  if (!degree.isComplete && pathname !== '/degree-wizard') return <Navigate to="/" replace />;
-
-  return (
-    <>
-      <Helmet>
-        <title>Circles</title>
-        <meta name="description" content="Circles UNSW Degree Planner" />
-        <meta name="keywords" content="circles, unsw, csesoc, degree, planner, course, plan" />
-      </Helmet>
-      {showHeader && <Header />}
-      <div>
-        {children}
-        <FeedbackButton />
-      </div>
-    </>
-  );
-};
+const PageTemplate = ({ children, showHeader = true }: Props) => (
+  <>
+    <Helmet>
+      <title>Circles</title>
+      <meta name="description" content="Circles UNSW Degree Planner" />
+      <meta name="keywords" content="circles, unsw, csesoc, degree, planner, course, plan" />
+    </Helmet>
+    {showHeader && <Header />}
+    <div>
+      {children}
+      <FeedbackButton />
+    </div>
+  </>
+);
 
 export default PageTemplate;

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -17,7 +17,8 @@ export const yellow = '#FAAD14';
 export const purple = '#9254de';
 export const lightPurple = '#efdbff';
 
-export const inDev = import.meta.env.MODE !== 'production';
+// export const inDev = import.meta.env.MODE !== 'production';
+export const inDev = false;
 
 export const MAX_COURSES_OVERFLOW = 80;
 export const COURSES_INITIALLY_COLLAPSED = 16;

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -17,8 +17,8 @@ export const yellow = '#FAAD14';
 export const purple = '#9254de';
 export const lightPurple = '#efdbff';
 
-// export const inDev = import.meta.env.MODE !== 'production';
-export const inDev = false;
+// export const inDev = false;
+export const inDev = import.meta.env.MODE !== 'production';
 
 export const MAX_COURSES_OVERFLOW = 80;
 export const COURSES_INITIALLY_COLLAPSED = 16;

--- a/frontend/src/pages/LandingPage/GetInvolved/GetInvolved.tsx
+++ b/frontend/src/pages/LandingPage/GetInvolved/GetInvolved.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Button } from 'antd';
+import PageContainer from 'styles/PageContainer';
+import { FEEDBACK_LINK } from 'config/constants';
+import S from './styles';
+
+const GetInvolved = () => {
+  return (
+    <PageContainer>
+      <S.Title>Interested in Circles?</S.Title>
+      <S.ContentWrapper>
+        If you&apos;re a CSE student with a keen interest in Circles and looking to get involved,
+        keep an eye out for our recruitment announcements on CSESoc&apos;s socials. Otherwise, you
+        can also contribute by suggesting cool new features, report any bugs or even make a pull
+        request on the Circles repo.
+      </S.ContentWrapper>
+      <S.LinksWrapper>
+        <Button href={FEEDBACK_LINK} target="_blank" rel="noreferrer" size="large" type="primary">
+          Feedback
+        </Button>
+        <Button
+          href="https://github.com/csesoc/circles"
+          target="_blank"
+          rel="noreferrer"
+          size="large"
+          type="primary"
+        >
+          Github
+        </Button>
+      </S.LinksWrapper>
+    </PageContainer>
+  );
+};
+
+export default GetInvolved;

--- a/frontend/src/pages/LandingPage/GetInvolved/index.ts
+++ b/frontend/src/pages/LandingPage/GetInvolved/index.ts
@@ -1,0 +1,3 @@
+import GetInvolved from './GetInvolved';
+
+export default GetInvolved;

--- a/frontend/src/pages/LandingPage/GetInvolved/styles.ts
+++ b/frontend/src/pages/LandingPage/GetInvolved/styles.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+const Title = styled.h1`
+  font-size: 50px;
+  margin-bottom: 3rem;
+  background: -webkit-linear-gradient(30deg, #9f62de, #b77eff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-align: center;
+  position: relative;
+  font-weight: 700;
+`;
+
+const ContentWrapper = styled.div`
+  text-align: center;
+  font-size: 1rem;
+`;
+
+const LinksWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 100px;
+  margin-top: 40px;
+  margin-bottom: 100px;
+`;
+
+export default {
+  Title,
+  ContentWrapper,
+  LinksWrapper
+};

--- a/frontend/src/pages/LandingPage/Hero/HeroContent/HeroContent.tsx
+++ b/frontend/src/pages/LandingPage/Hero/HeroContent/HeroContent.tsx
@@ -10,15 +10,17 @@ const HeroContent = () => (
     <S.HeroTitle animate={{ x: [-60, 10, 0] }} transition={{ duration: 1, ease: 'easeInOut' }}>
       Degree planning made <S.HeroSubTitle src={easySubTitle} alt="Hero Subtitle" />
     </S.HeroTitle>
-    <S.HeroCTA
-      initial={{ scale: 0.0 }}
-      animate={{ scale: 1 }}
-      transition={{ type: 'spring', stiffness: 400, damping: 10 }}
-      whileHover={{ scale: 1.1 }}
-    >
-      <Link to="/degree-wizard">START</Link>
-      <ArrowRightOutlined style={{ strokeWidth: '5rem', stroke: '#9453e6' }} />
-    </S.HeroCTA>
+    <Link to="/degree-wizard">
+      <S.HeroCTA
+        initial={{ scale: 0.0 }}
+        animate={{ scale: 1 }}
+        transition={{ type: 'spring', stiffness: 400, damping: 10 }}
+        whileHover={{ scale: 1.1 }}
+      >
+        START
+        <ArrowRightOutlined style={{ strokeWidth: '5rem', stroke: '#9453e6' }} />
+      </S.HeroCTA>
+    </Link>
     <S.CSESocLogo
       src={cseLogo}
       alt="CSE Logo"

--- a/frontend/src/pages/LandingPage/Hero/HeroContent/styles.ts
+++ b/frontend/src/pages/LandingPage/Hero/HeroContent/styles.ts
@@ -26,7 +26,7 @@ const HeroCTA = motion(styled.button`
   border-radius: 50px;
   background-color: #fff;
   border: none;
-  width: 30%;
+  width: 200px;
   height: 3.5rem;
   cursor: pointer;
   margin-bottom: 2.5rem;

--- a/frontend/src/pages/LandingPage/Hero/HeroHeader/HeroHeader.tsx
+++ b/frontend/src/pages/LandingPage/Hero/HeroHeader/HeroHeader.tsx
@@ -6,7 +6,7 @@ import S from './styles';
 
 const HeroHeader = () => (
   <S.Header animate={{ y: 0 }} initial={{ y: -40 }} transition={{ duration: 0.5, ease: 'easeOut' }}>
-    <Link to="/landing-page">
+    <Link to="/">
       <S.LogoWrapper>
         <S.HeaderLogo src={circlesLogo} alt="Circles Logo" />
         <S.HeaderTitle>Circles</S.HeaderTitle>

--- a/frontend/src/pages/LandingPage/Hero/HeroHeader/styles.ts
+++ b/frontend/src/pages/LandingPage/Hero/HeroHeader/styles.ts
@@ -21,6 +21,7 @@ const LoginButton = styled.button`
   padding: 6px 0;
   transition: all 0.1s;
   z-index: 1;
+  letter-spacing: 0.8px;
 
   &:hover {
     background: #e3a4fa;

--- a/frontend/src/pages/LandingPage/HowToUse/styles.ts
+++ b/frontend/src/pages/LandingPage/HowToUse/styles.ts
@@ -2,8 +2,7 @@ import { motion } from 'framer-motion';
 import styled from 'styled-components';
 
 const StyledWrapper = styled.div`
-  margin-top: -5rem;
-  margin-bottom: 20rem;
+  margin-bottom: 80px;
 `;
 
 const Title = styled.h1`

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { inDev } from 'config/constants';
 import Footer from './FooterSection/Footer';
+import GetInvolved from './GetInvolved';
 import Hero from './Hero';
 import HowToUse from './HowToUse';
 import InteractiveViewSection from './InteractiveViewSection';
@@ -9,8 +11,9 @@ const LandingPage = () => (
   <>
     <Hero />
     <KeyFeaturesSection />
-    <InteractiveViewSection />
+    {inDev && <InteractiveViewSection />}
     <HowToUse />
+    <GetInvolved />
     <Footer />
   </>
 );


### PR DESCRIPTION
Changes made:
- made landing page as root route and fix references to load up correct page depending on context (i.e. first visit will redirect user to the landing page, existing users will be taken to course selector).
- This PR once merged, will make the landing page publicly availiable in production
- Added a 'Get Involved' section to fill whitespace between 'How it works' section and footer
![image](https://user-images.githubusercontent.com/65492346/210124310-a08fd17c-08f4-422c-bbe1-2317569ba060.png)
