### PR TITLE
bug(backend) fix unhashable json in conditions.py

### DIFF
--- a/backend/algorithms/objects/conditions.py
+++ b/backend/algorithms/objects/conditions.py
@@ -145,7 +145,7 @@ class CoreqCourseCondition(Condition):
 
     def __str__(self) -> str:
         return json.dumps({
-            {'id': self.course}
+            'id': self.course
         })
 
 class UOCCondition(Condition):


### PR DESCRIPTION
- this causes crash because cannot push a dict inside a set since it is unhashable
- will occasionally break the jsonified route
- simple fix: remove the extraneous set of brackets