### PR TITLE
chore: Made vscode use mypy from the Python extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,10 +5,13 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.testing.cwd": "${workspaceFolder}/backend",
-    "mypy.configFile": "./backend/mypy.ini",
     "files.exclude": {
         "**/__pycache__": true,
         "**/.hypothesis": true,
         "**/.pytest_cache": true
-    }
+    },
+    "python.linting.mypyEnabled": true,
+    "python.linting.mypyArgs": [
+        "--config-file=${workspaceFolder}/backend/mypy.ini"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.testing.cwd": "${workspaceFolder}/backend",
+    "mypy.configFile": "./backend/mypy.ini",
     "files.exclude": {
         "**/__pycache__": true,
         "**/.hypothesis": true,


### PR DESCRIPTION
Previously we used `"mypy.configFile": "./backend/mypy.ini",` in `.vscode/settings.json` to point the [vscode mypy extension](https://marketplace.visualstudio.com/items?itemName=matangover.mypy) at the mypy config file in the backend directory. However, the normal Python extension has since added support for mypy. This should enable that and point it at the config file.