### PR TITLE
chore: make linefeed the default end-of-line in workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
     "python.linting.mypyArgs": [
         "--config-file=${workspaceFolder}/backend/mypy.ini"
     ],
-    "python.analysis.typeCheckingMode": "basic"
+    "python.analysis.typeCheckingMode": "basic",
+    "files.eol": "\n"
 }

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -2,5 +2,6 @@
     "semi": true,
     "tabWidth": 2,
     "printWidth": 100,
-    "singleQuote": true
+    "singleQuote": true,
+    "trailingComma": "none"
 }

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -2,6 +2,5 @@
     "semi": true,
     "tabWidth": 2,
     "printWidth": 100,
-    "singleQuote": true,
-    "trailingComma": "none"
+    "singleQuote": true
 }


### PR DESCRIPTION
rationale: windows and their `\r\n` 