### PR TITLE
feat(BE/FE): replace toggleSummer reducer with API [CF-412]

### DIFF
--- a/backend/server/example_input/example_local_storage_data.json
+++ b/backend/server/example_input/example_local_storage_data.json
@@ -36,6 +36,96 @@
             "courses": {}
         }
     },
+    "summer_term": {
+        "degree": {
+            "programCode": "3707",
+            "specs": [ "COMPA1" ],
+            "isComplete": true
+        },
+        "planner": {
+            "years": [ {
+                    "T0": [
+                        "COMP1511",
+                        "MATH1141"
+                    ],
+                    "T1": [],
+                    "T2": [],
+                    "T3": []
+                },
+                {
+                    "T0": [
+                        "MATH1081"
+                    ],
+                    "T1": [],
+                    "T2": [],
+                    "T3": []
+                }
+            ],
+            "mostRecentPastTerm": {
+                "Y": 1,
+                "T": 0
+            },
+            "unplanned": [],
+            "startYear": 2020,
+            "numYears": 2,
+            "isSummerEnabled": true,
+            "courses": {
+                "COMP1511": {
+                    "title": "Programming Fundamentals",
+                    "termsOffered": [
+                        "T1",
+                        "T2",
+                        "T3"
+                    ],
+                    "UOC": 6,
+                    "plannedFor": "2020T0",
+                    "prereqs": "",
+                    "isLegacy": false,
+                    "isUnlocked": true,
+                    "warnings": [],
+                    "handbookNote": "",
+                    "isAccurate": true,
+                    "isMultiterm": false,
+                    "supressed": false
+                },
+                "MATH1141": {
+                    "title": "Higher Mathematics 1A",
+                    "termsOffered": [
+                        "T1",
+                        "T2"
+                    ],
+                    "UOC": 6,
+                    "plannedFor": "2020T0",
+                    "prereqs": "",
+                    "isLegacy": false,
+                    "isUnlocked": true,
+                    "warnings": [],
+                    "handbookNote": "",
+                    "isAccurate": true,
+                    "isMultiterm": false,
+                    "supressed": false
+                },
+                "MATH1081": {
+                    "title": "Discrete Mathematics",
+                    "termsOffered": [
+                        "T1",
+                        "T2",
+                        "T3"
+                    ],
+                    "UOC": 6,
+                    "plannedFor": "2021T1",
+                    "prereqs": "",
+                    "isLegacy": false,
+                    "isUnlocked": true,
+                    "warnings": [],
+                    "handbookNote": "",
+                    "isAccurate": true,
+                    "isMultiterm": false,
+                    "supressed": false
+                }
+            }
+        }
+    },
     "simple_year": {
         "degree": {
             "programCode": "3707",

--- a/backend/server/routers/user.py
+++ b/backend/server/routers/user.py
@@ -118,6 +118,10 @@ def default_cs_user() -> Storage:
 def toggle_summer_term(token: str = DUMMY_TOKEN):
     user = get_user(token)
     user['planner']['isSummerEnabled'] = not user['planner']['isSummerEnabled']
+    if not user['planner']['isSummerEnabled']:
+        for year in user['planner']['years']:
+            user['planner']['unplanned'].extend(year['T0'])
+            year['T0'] = []
     set_user(token, user, True)
 
 

--- a/backend/server/tests/user/test_toggle_summer_term.py
+++ b/backend/server/tests/user/test_toggle_summer_term.py
@@ -12,10 +12,14 @@ with open(PATH, encoding="utf8") as f:
 def test_toggleSummerTerm():
     clear()
     x = requests.post(
-        'http://127.0.0.1:8000/user/saveLocalStorage', json=DATA["empty_year"])
+        'http://127.0.0.1:8000/user/saveLocalStorage', json=DATA["summer_term"])
     assert x.status_code == 200
     data = requests.get(f'http://127.0.0.1:8000/user/data/all/{DUMMY_TOKEN}')
     assert data.json()["planner"]["isSummerEnabled"]
     requests.put('http://127.0.0.1:8000/user/toggleSummerTerm')
     data = requests.get(f'http://127.0.0.1:8000/user/data/all/{DUMMY_TOKEN}')
     assert not data.json()["planner"]["isSummerEnabled"]
+    assert data.json()["planner"]["years"][0]["T0"] == []
+    assert data.json()["planner"]["years"][1]["T0"] == []
+    assert data.json()["planner"]["unplanned"] == [
+        "COMP1511", "MATH1141", "MATH1081"]

--- a/frontend/src/pages/TermPlanner/ImportPlannerMenu/ImportPlannerMenu.tsx
+++ b/frontend/src/pages/TermPlanner/ImportPlannerMenu/ImportPlannerMenu.tsx
@@ -7,7 +7,7 @@ import { Course } from 'types/api';
 import { JSONPlanner, Term, UnPlannedToTerm } from 'types/planner';
 import openNotification from 'utils/openNotification';
 import type { RootState } from 'config/store';
-import { moveCourse, toggleSummer } from 'reducers/plannerSlice';
+import { moveCourse } from 'reducers/plannerSlice';
 import CS from '../common/styles';
 import S from './styles';
 
@@ -108,7 +108,16 @@ const ImportPlannerMenu = () => {
             return;
           }
           if (planner.isSummerEnabled !== fileInJson.isSummerEnabled) {
-            dispatch(toggleSummer());
+            try {
+              axios.post('/user/toggleSummerTerm', {}, { params: { token } });
+            } catch {
+              openNotification({
+                type: 'error',
+                message: 'Error setting summer term',
+                description: 'An error occurred when toggling the summer term.'
+              });
+              return;
+            }
           }
           fileInJson.years.forEach((year, yearIndex) => {
             Object.entries(year).forEach(([term, termCourses]) => {

--- a/frontend/src/pages/TermPlanner/ImportPlannerMenu/ImportPlannerMenu.tsx
+++ b/frontend/src/pages/TermPlanner/ImportPlannerMenu/ImportPlannerMenu.tsx
@@ -114,7 +114,7 @@ const ImportPlannerMenu = () => {
               openNotification({
                 type: 'error',
                 message: 'Error setting summer term',
-                description: 'An error occurred when toggling the summer term.'
+                description: 'An error occurred when trying to import summer term visibility'
               });
               return;
             }

--- a/frontend/src/pages/TermPlanner/ImportPlannerMenu/ImportPlannerMenu.tsx
+++ b/frontend/src/pages/TermPlanner/ImportPlannerMenu/ImportPlannerMenu.tsx
@@ -109,7 +109,7 @@ const ImportPlannerMenu = () => {
           }
           if (planner.isSummerEnabled !== fileInJson.isSummerEnabled) {
             try {
-              axios.post('/user/toggleSummerTerm', {}, { params: { token } });
+              await axios.post('/user/toggleSummerTerm', {}, { params: { token } });
             } catch {
               openNotification({
                 type: 'error',

--- a/frontend/src/pages/TermPlanner/SettingsMenu/SettingsMenu.tsx
+++ b/frontend/src/pages/TermPlanner/SettingsMenu/SettingsMenu.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { Select, Switch } from 'antd';
 import axios from 'axios';
@@ -7,7 +7,6 @@ import dayjs from 'dayjs';
 import openNotification from 'utils/openNotification';
 import Spinner from 'components/Spinner';
 import type { RootState } from 'config/store';
-import { toggleSummer } from 'reducers/plannerSlice';
 import CS from '../common/styles';
 
 const DatePicker = React.lazy(() => import('components/Datepicker'));
@@ -16,8 +15,6 @@ const SettingsMenu = () => {
   const { Option } = Select;
   const { isSummerEnabled, numYears, startYear } = useSelector((state: RootState) => state.planner);
   const { token } = useSelector((state: RootState) => state.settings);
-
-  const dispatch = useDispatch();
 
   async function handleUpdateStartYear(_: dayjs.Dayjs | null, dateString: string) {
     if (dateString) {
@@ -50,7 +47,16 @@ const SettingsMenu = () => {
   }
 
   function handleSummerToggle() {
-    dispatch(toggleSummer());
+    try {
+      axios.post('/user/toggleSummerTerm', {}, { params: { token } });
+    } catch {
+      openNotification({
+        type: 'error',
+        message: 'Error setting summer term',
+        description: 'An error occurred when toggling the summer term.'
+      });
+      return;
+    }
     if (isSummerEnabled) {
       openNotification({
         type: 'info',

--- a/frontend/src/pages/TermPlanner/SettingsMenu/SettingsMenu.tsx
+++ b/frontend/src/pages/TermPlanner/SettingsMenu/SettingsMenu.tsx
@@ -46,9 +46,9 @@ const SettingsMenu = () => {
     }
   }
 
-  function handleSummerToggle() {
+  async function handleSummerToggle() {
     try {
-      axios.post('/user/toggleSummerTerm', {}, { params: { token } });
+      await axios.post('/user/toggleSummerTerm', {}, { params: { token } });
     } catch {
       openNotification({
         type: 'error',


### PR DESCRIPTION
Replaces the toggleSummer plannerSlice reducer with the matching backend API (`/user/toggleSummerTerm`)