### PR TITLE
feat(BE/FE): replace updateStartYear reducer with API [CF-413]

### DIFF
--- a/backend/server/routers/user.py
+++ b/backend/server/routers/user.py
@@ -86,7 +86,7 @@ def default_cs_user() -> Storage:
             'T': 0
         },
         'unplanned': [],
-        'isSummerEnabled': True, 
+        'isSummerEnabled': True,
         'startYear': LIVE_YEAR,
         'years': [],
         'courses': {},
@@ -128,24 +128,11 @@ def update_course_mark(courseMark: CourseMark, token: str = DUMMY_TOKEN):
 @router.put("/updateStartYear")
 def update_start_year(startYear: int, token: str = DUMMY_TOKEN):
     """
-        update the start year the user is taking. We assume that the number of years
-        will stay the same, and that the user will want their courses to be matched
-        *by year taken*.
+        Update the start year the user is taking.
+        The degree length stays the same and the contents are shifted to fit the new start year.
     """
     user = get_user(token)
-    if startYear == user['planner']['startYear']:
-        return
-    diff = abs(startYear - user['planner']['startYear'])
-    if startYear > user['planner']['startYear']:
-        # yeet the early years and add back the years to the end
-        user['planner']['years'] = \
-            user['planner']['years'][diff:] + \
-            ([{"T0": [], "T1": [], "T2": [], "T3": []}] * diff)
-    else:
-        # pad the beginning and yeet the end
-        user['planner']['years'] = \
-            ([{"T0": [], "T1": [], "T2": [], "T3": []}] * diff) + \
-            user['planner']['years'][:-diff]  # type: ignore
+    user['planner']['startYear'] = startYear
     set_user(token, user, True)
 
 

--- a/backend/server/tests/user/test_update_start_year.py
+++ b/backend/server/tests/user/test_update_start_year.py
@@ -16,9 +16,8 @@ def test_updateCourseMark_back_time_2019():
         f'http://127.0.0.1:8000/user/updateStartYear?startYear=2019')
     user_after = requests.get(f'http://127.0.0.1:8000/user/data/{DUMMY_TOKEN}').json()
     assert len(user_before['planner']['years']) == len(user_after['planner']['years'])
-    assert user_after['planner']['years'][0] == {"T0": [], "T1": [], "T2": [], "T3": []}
-    assert user_after['planner']['years'][1] == { "T0": [], "T1": [ "COMP1511", "MATH1141", "MATH1081"], "T2": [ "COMP1521", "COMP1531", "COMP2521"], "T3": []}
-    assert user_after['planner']['years'][2] == {"T0": [], "T1": ["ENGG2600"], "T2": ["ENGG2600"], "T3": ["ENGG2600"]}
+    assert user_before['planner']['years'] == user_after['planner']['years']
+    assert user_after['planner']['startYear'] == 2019
     
 
 def test_updateCourseMark_back_time_2018():
@@ -30,9 +29,8 @@ def test_updateCourseMark_back_time_2018():
         f'http://127.0.0.1:8000/user/updateStartYear?startYear=2018')
     user_after = requests.get(f'http://127.0.0.1:8000/user/data/{DUMMY_TOKEN}').json()
     assert len(user_before['planner']['years']) == len(user_after['planner']['years'])
-    assert user_after['planner']['years'][0] == {"T0": [], "T1": [], "T2": [], "T3": []}
-    assert user_after['planner']['years'][1] == {"T0": [], "T1": [], "T2": [], "T3": []}
-    assert user_after['planner']['years'][2] == { "T0": [], "T1": [ "COMP1511", "MATH1141", "MATH1081"], "T2": [ "COMP1521", "COMP1531", "COMP2521"], "T3": []}
+    assert user_before['planner']['years'] == user_after['planner']['years']
+    assert user_after['planner']['startYear'] == 2018
 
 def test_updateCourseMark_forward_time_2021():
     clear()
@@ -43,6 +41,5 @@ def test_updateCourseMark_forward_time_2021():
         f'http://127.0.0.1:8000/user/updateStartYear?startYear=2021')
     user_after = requests.get(f'http://127.0.0.1:8000/user/data/{DUMMY_TOKEN}').json()
     assert len(user_before['planner']['years']) == len(user_after['planner']['years'])
-    assert user_after['planner']['years'][0] == {"T0": [], "T1": ["ENGG2600"], "T2": ["ENGG2600"], "T3": ["ENGG2600"]}
-    assert user_after['planner']['years'][1] == {"T0": [], "T1": [], "T2": [], "T3": []}
-    assert user_after['planner']['years'][2] == {"T0": [], "T1": [], "T2": [], "T3": []}
+    assert user_before['planner']['years'] == user_after['planner']['years']
+    assert user_after['planner']['startYear'] == 2021

--- a/frontend/src/pages/DegreeWizard/YearStep/YearStep.tsx
+++ b/frontend/src/pages/DegreeWizard/YearStep/YearStep.tsx
@@ -7,7 +7,6 @@ import openNotification from 'utils/openNotification';
 import Spinner from 'components/Spinner';
 import { RootState } from 'config/store';
 import { useAppDispatch } from 'hooks';
-import { updateStartYear } from 'reducers/plannerSlice';
 import springProps from '../common/spring';
 import Steps from '../common/steps';
 import CS from '../common/styles';
@@ -41,19 +40,24 @@ const YearStep = ({ incrementStep }: Props) => {
               width: '100%'
             }}
             onChange={async (_, [startYear, endYear]: [string, string]) => {
-              const numYears = parseInt(endYear, 10) - parseInt(startYear, 10) + 1;
+              const startYearInt = parseInt(startYear, 10);
+              const numYears = parseInt(endYear, 10) - startYearInt + 1;
               // We can trust num years to be a valid number because the range picker only allows valid ranges
               try {
                 await axios.put('/user/updateDegreeLength', { numYears }, { params: { token } });
+                await axios.put(
+                  '/user/updateStartYear',
+                  { startYear: startYearInt },
+                  { params: { token } }
+                );
               } catch {
                 openNotification({
                   type: 'error',
-                  message: 'Error updating degree length',
-                  description: 'There was an error updating the degree length.'
+                  message: 'Error setting degree start year or length',
+                  description: 'There was an error updating the degree start year or length.'
                 });
                 return;
               }
-              dispatch(updateStartYear(parseInt(startYear, 10)));
 
               if (startYear && endYear) incrementStep(Steps.DEGREE);
             }}

--- a/frontend/src/pages/TermPlanner/ImportPlannerMenu/ImportPlannerMenu.tsx
+++ b/frontend/src/pages/TermPlanner/ImportPlannerMenu/ImportPlannerMenu.tsx
@@ -11,8 +11,7 @@ import {
   addToUnplanned,
   moveCourse,
   setUnplannedCourseToTerm,
-  toggleSummer,
-  updateStartYear
+  toggleSummer
 } from 'reducers/plannerSlice';
 import CS from '../common/styles';
 import S from './styles';
@@ -82,15 +81,19 @@ const ImportPlannerMenu = () => {
               { numYears: fileInJson.numYears },
               { params: { token } }
             );
+            await axios.put(
+              '/user/updateStartYear',
+              { startYear: fileInJson.startYear },
+              { params: { token } }
+            );
           } catch {
             openNotification({
               type: 'error',
-              message: 'Error setting degree length',
-              description: 'There was an error updating the degree length.'
+              message: 'Error setting degree start year or length',
+              description: 'There was an error updating the degree start year or length.'
             });
             return;
           }
-          dispatch(updateStartYear(fileInJson.startYear));
           if (planner.isSummerEnabled !== fileInJson.isSummerEnabled) {
             dispatch(toggleSummer());
           }

--- a/frontend/src/pages/TermPlanner/SettingsMenu/SettingsMenu.tsx
+++ b/frontend/src/pages/TermPlanner/SettingsMenu/SettingsMenu.tsx
@@ -7,7 +7,7 @@ import dayjs from 'dayjs';
 import openNotification from 'utils/openNotification';
 import Spinner from 'components/Spinner';
 import type { RootState } from 'config/store';
-import { toggleSummer, updateStartYear } from 'reducers/plannerSlice';
+import { toggleSummer } from 'reducers/plannerSlice';
 import CS from '../common/styles';
 
 const DatePicker = React.lazy(() => import('components/Datepicker'));
@@ -19,9 +19,21 @@ const SettingsMenu = () => {
 
   const dispatch = useDispatch();
 
-  function handleUpdateStartYear(_: dayjs.Dayjs | null, dateString: string) {
+  async function handleUpdateStartYear(_: dayjs.Dayjs | null, dateString: string) {
     if (dateString) {
-      dispatch(updateStartYear(parseInt(dateString, 10)));
+      try {
+        await axios.put(
+          '/user/updateStartYear',
+          { startYear: parseInt(dateString, 10) },
+          { params: { token } }
+        );
+      } catch {
+        openNotification({
+          type: 'error',
+          message: 'Error setting degree start year',
+          description: 'There was an error updating the degree start year.'
+        });
+      }
     }
   }
 


### PR DESCRIPTION
- Replaces the updateStartYear degreePlanner slice with the according backend API call.
- Updates the logic of updating a start year; now changing the start year will move all planned items to the correct relative year. (i.e. courses planned in 2025 will go to 2024 if the start year is shifted back by one)