### PR TITLE
feat(frontend) fuzzy-find-degree-wizard

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "antd": "4.24.8",
         "axios": "1.2.1",
         "dayjs": "1.11.7",
+        "fast-fuzzy": "^1.12.0",
         "framer-motion": "^10.0.0",
         "rc-picker": "3.1.2",
         "react": "18.2.0",
@@ -5361,6 +5362,14 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "node_modules/fast-fuzzy": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fast-fuzzy/-/fast-fuzzy-1.12.0.tgz",
+      "integrity": "sha512-sXxGgHS+ubYpsdLnvOvJ9w5GYYZrtL9mkosG3nfuD446ahvoWEsSKBP7ieGmWIKVLnaxRDgUJkZMdxRgA2Ni+Q==",
+      "dependencies": {
+        "graphemesplit": "^2.4.1"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -5799,6 +5808,15 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
+    },
+    "node_modules/graphemesplit": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/graphemesplit/-/graphemesplit-2.4.4.tgz",
+      "integrity": "sha512-lKrpp1mk1NH26USxC/Asw4OHbhSQf5XfrWZ+CDv/dFVvd1j17kFgMotdJvOesmHkbFX9P9sBfpH8VogxOWLg8w==",
+      "dependencies": {
+        "js-base64": "^3.6.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/graphlib": {
       "version": "2.1.8",
@@ -6929,6 +6947,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
+      "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
+    },
     "node_modules/js-sdsl": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
@@ -7762,6 +7785,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -9838,6 +9866,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
@@ -10120,6 +10153,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/universalify": {
@@ -15065,6 +15107,14 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-fuzzy": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/fast-fuzzy/-/fast-fuzzy-1.12.0.tgz",
+      "integrity": "sha512-sXxGgHS+ubYpsdLnvOvJ9w5GYYZrtL9mkosG3nfuD446ahvoWEsSKBP7ieGmWIKVLnaxRDgUJkZMdxRgA2Ni+Q==",
+      "requires": {
+        "graphemesplit": "^2.4.1"
+      }
+    },
     "fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -15385,6 +15435,15 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
+    },
+    "graphemesplit": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/graphemesplit/-/graphemesplit-2.4.4.tgz",
+      "integrity": "sha512-lKrpp1mk1NH26USxC/Asw4OHbhSQf5XfrWZ+CDv/dFVvd1j17kFgMotdJvOesmHkbFX9P9sBfpH8VogxOWLg8w==",
+      "requires": {
+        "js-base64": "^3.6.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "graphlib": {
       "version": "2.1.8",
@@ -16190,6 +16249,11 @@
         }
       }
     },
+    "js-base64": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
+      "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
+    },
     "js-sdsl": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
@@ -16833,6 +16897,11 @@
       "requires": {
         "p-limit": "^3.0.2"
       }
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -18329,6 +18398,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
+    "tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    },
     "tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
@@ -18551,6 +18625,15 @@
         "has-bigints": "^1.0.2",
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "requires": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "universalify": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,6 @@
         "axios": "1.2.1",
         "dayjs": "1.11.7",
         "framer-motion": "^10.0.0",
-        "levenshtein-edit-distance": "^3.0.1",
         "rc-picker": "3.1.2",
         "react": "18.2.0",
         "react-beautiful-dnd": "13.1.1",
@@ -7206,18 +7205,6 @@
       "optional": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/levenshtein-edit-distance": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-3.0.1.tgz",
-      "integrity": "sha512-/qMCkZbrAF7jZP/voqlkfNrBtEn0TMdhCK7OEBh/zb39t/c3wCnTjwU1ZvrMfQ3OxB8sBQXIpWRMM6FiQJVG3g==",
-      "bin": {
-        "levenshtein-edit-distance": "cli.js"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/levn": {
@@ -16423,11 +16410,6 @@
           "optional": true
         }
       }
-    },
-    "levenshtein-edit-distance": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-3.0.1.tgz",
-      "integrity": "sha512-/qMCkZbrAF7jZP/voqlkfNrBtEn0TMdhCK7OEBh/zb39t/c3wCnTjwU1ZvrMfQ3OxB8sBQXIpWRMM6FiQJVG3g=="
     },
     "levn": {
       "version": "0.4.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "axios": "1.2.1",
         "dayjs": "1.11.7",
         "framer-motion": "^10.0.0",
+        "levenshtein-edit-distance": "^3.0.1",
         "rc-picker": "3.1.2",
         "react": "18.2.0",
         "react-beautiful-dnd": "13.1.1",
@@ -7205,6 +7206,18 @@
       "optional": true,
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/levenshtein-edit-distance": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-3.0.1.tgz",
+      "integrity": "sha512-/qMCkZbrAF7jZP/voqlkfNrBtEn0TMdhCK7OEBh/zb39t/c3wCnTjwU1ZvrMfQ3OxB8sBQXIpWRMM6FiQJVG3g==",
+      "bin": {
+        "levenshtein-edit-distance": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/levn": {
@@ -16410,6 +16423,11 @@
           "optional": true
         }
       }
+    },
+    "levenshtein-edit-distance": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-3.0.1.tgz",
+      "integrity": "sha512-/qMCkZbrAF7jZP/voqlkfNrBtEn0TMdhCK7OEBh/zb39t/c3wCnTjwU1ZvrMfQ3OxB8sBQXIpWRMM6FiQJVG3g=="
     },
     "levn": {
       "version": "0.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "antd": "4.24.8",
     "axios": "1.2.1",
     "dayjs": "1.11.7",
+    "fast-fuzzy": "^1.12.0",
     "framer-motion": "^10.0.0",
     "rc-picker": "3.1.2",
     "react": "18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
     "axios": "1.2.1",
     "dayjs": "1.11.7",
     "framer-motion": "^10.0.0",
-    "levenshtein-edit-distance": "^3.0.1",
     "rc-picker": "3.1.2",
     "react": "18.2.0",
     "react-beautiful-dnd": "13.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "axios": "1.2.1",
     "dayjs": "1.11.7",
     "framer-motion": "^10.0.0",
+    "levenshtein-edit-distance": "^3.0.1",
     "rc-picker": "3.1.2",
     "react": "18.2.0",
     "react-beautiful-dnd": "13.1.1",

--- a/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.test.tsx
+++ b/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
@@ -71,11 +71,5 @@ describe('DegreeStep', () => {
     await renderWithProviders(<DegreeStep incrementStep={incrementStepMock} />);
     await userEvent.type(screen.getByPlaceholderText('Search Degree'), 'computer science');
     expect(await screen.findByText('3778 Computer Science')).toBeInTheDocument();
-  });
-
-  it('should not show degree options if no match', async () => {
-    await renderWithProviders(<DegreeStep incrementStep={incrementStepMock} />);
-    await userEvent.type(screen.getByPlaceholderText('Search Degree'), 'Degree that does not exist');
-    expect(within(screen.queryByTestId('antd-degree-menu') || document.createElement('ul')).queryAllByRole('menuitem')).toHaveLength(0);
   });
 });

--- a/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
+++ b/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
@@ -50,37 +50,21 @@ const DegreeStep = ({ incrementStep }: Props) => {
   };
 
   const searchDegree = (newInput: string) => {
-    console.log(`Starting fuzzy on ${newInput}`);
     setInput(newInput);
-    const degreeOptions = Object.keys(allDegrees);
-    console.log(`degreeOptions`, degreeOptions);
 
-    const afterCombine = degreeOptions
+    const fuzzedDegrees = Object.keys(allDegrees)
       .map((code) => `${code} ${allDegrees[code]}`)
-      .splice(0, 100);
-    console.log(`afterCombine: ${afterCombine}`);
-
-    const afterDistancce = afterCombine
       .map((title) => {
         return {
           'distance': fuzzy(newInput, title),
           'name': title
         }
-      }).splice(0, 100);
-    console.log(`afterDistancce: `, afterDistancce);
+      });
 
-    afterDistancce.sort((a, b) => a.name.length - b.name.length);
-    afterDistancce.sort((a, b) => b.distance - a.distance);
-    const afterSort = afterDistancce;
-    console.log(`afterSort: `, afterSort);
+    fuzzedDegrees.sort((a, b) => a.name.length - b.name.length);
+    fuzzedDegrees.sort((a, b) => b.distance - a.distance);
 
-    const afterSplice = afterSort.splice(0, 100);
-    console.log(`afterSplice: `, afterSplice);
-
-    const afterMap = afterSplice.map(pair => pair.name);
-    console.log(`afterMap: `, afterMap);
-
-    setOptions(afterMap);
+    setOptions(fuzzedDegrees.splice(0, 100).map(pair => pair.name));
   };
 
   const props = useSpring(springProps);

--- a/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
+++ b/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
@@ -54,7 +54,7 @@ const DegreeStep = ({ incrementStep }: Props) => {
     console.log(`Starting fuzzy on ${newInput}`);
     setInput(newInput);
     const degreeOptions = Object.keys(allDegrees);
-    console.log(`degreeOptions: ${degreeOptions}`);
+    console.log(`degreeOptions`, degreeOptions);
 
     const afterCombine = degreeOptions
       .map((code) => `${code} ${allDegrees[code]}`);
@@ -67,17 +67,17 @@ const DegreeStep = ({ incrementStep }: Props) => {
           'name': title
         }
       });
-    console.log(`afterDistancce: ${afterDistancce}`);
+    console.log(`afterDistancce: `, afterDistancce);
 
     afterDistancce.sort((a, b) => a.distance - b.distance);
     const afterSort = afterDistancce;
-    console.log(`afterSort: ${afterSort}`);
+    console.log(`afterSort: `, afterSort);
 
     const afterSplice = afterSort.splice(0, 10);
-    console.log(`afterSplice: ${afterSplice}`);
+    console.log(`afterSplice: `, afterSplice);
 
     const afterMap = afterSplice.map(pair => pair.name);
-    console.log(`afterMap: ${afterMap}`);
+    console.log(`afterMap: `, afterMap);
 
     setOptions(afterMap);
   };

--- a/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
+++ b/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
@@ -10,8 +10,7 @@ import { resetDegree, setProgram } from 'reducers/degreeSlice';
 import springProps from '../common/spring';
 import Steps from '../common/steps';
 import CS from '../common/styles';
-
-import { levenshteinEditDistance } from 'levenshtein-edit-distance';
+import { fuzzy } from 'fast-fuzzy';
 
 const { Title } = Typography;
 
@@ -57,23 +56,25 @@ const DegreeStep = ({ incrementStep }: Props) => {
     console.log(`degreeOptions`, degreeOptions);
 
     const afterCombine = degreeOptions
-      .map((code) => `${code} ${allDegrees[code]}`);
+      .map((code) => `${code} ${allDegrees[code]}`)
+      .splice(0, 100);
     console.log(`afterCombine: ${afterCombine}`);
 
     const afterDistancce = afterCombine
       .map((title) => {
         return {
-          'distance': levenshteinEditDistance(newInput, title),
+          'distance': fuzzy(newInput, title),
           'name': title
         }
-      });
+      }).splice(0, 100);
     console.log(`afterDistancce: `, afterDistancce);
 
-    afterDistancce.sort((a, b) => a.distance - b.distance);
+    afterDistancce.sort((a, b) => a.name.length - b.name.length);
+    afterDistancce.sort((a, b) => b.distance - a.distance);
     const afterSort = afterDistancce;
     console.log(`afterSort: `, afterSort);
 
-    const afterSplice = afterSort.splice(0, 10);
+    const afterSplice = afterSort.splice(0, 100);
     console.log(`afterSplice: `, afterSplice);
 
     const afterMap = afterSplice.map(pair => pair.name);

--- a/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
+++ b/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
@@ -1,8 +1,8 @@
-/* eslint-disable */
 import React, { useEffect, useState } from 'react';
 import { animated, useSpring } from '@react-spring/web';
 import { Input, Menu, Typography } from 'antd';
 import axios from 'axios';
+import { fuzzy } from 'fast-fuzzy';
 import { Programs } from 'types/api';
 import type { RootState } from 'config/store';
 import { useAppDispatch, useAppSelector } from 'hooks';
@@ -10,7 +10,6 @@ import { resetDegree, setProgram } from 'reducers/degreeSlice';
 import springProps from '../common/spring';
 import Steps from '../common/steps';
 import CS from '../common/styles';
-import { fuzzy } from 'fast-fuzzy';
 
 const { Title } = Typography;
 
@@ -56,15 +55,15 @@ const DegreeStep = ({ incrementStep }: Props) => {
       .map((code) => `${code} ${allDegrees[code]}`)
       .map((title) => {
         return {
-          'distance': fuzzy(newInput, title),
-          'name': title
-        }
+          distance: fuzzy(newInput, title),
+          name: title
+        };
       });
 
     fuzzedDegrees.sort((a, b) => a.name.length - b.name.length);
     fuzzedDegrees.sort((a, b) => b.distance - a.distance);
 
-    setOptions(fuzzedDegrees.splice(0, 100).map(pair => pair.name));
+    setOptions(fuzzedDegrees.splice(0, 8).map((pair) => pair.name));
   };
 
   const props = useSpring(springProps);

--- a/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
+++ b/frontend/src/pages/DegreeWizard/DegreeStep/DegreeStep.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, { useEffect, useState } from 'react';
 import { animated, useSpring } from '@react-spring/web';
 import { Input, Menu, Typography } from 'antd';
@@ -9,6 +10,8 @@ import { resetDegree, setProgram } from 'reducers/degreeSlice';
 import springProps from '../common/spring';
 import Steps from '../common/steps';
 import CS from '../common/styles';
+
+import { levenshteinEditDistance } from 'levenshtein-edit-distance';
 
 const { Title } = Typography;
 
@@ -48,12 +51,35 @@ const DegreeStep = ({ incrementStep }: Props) => {
   };
 
   const searchDegree = (newInput: string) => {
+    console.log(`Starting fuzzy on ${newInput}`);
     setInput(newInput);
-    const degreeOptions = Object.keys(allDegrees)
-      .map((code) => `${code} ${allDegrees[code]}`)
-      .filter((degree) => degree.toLowerCase().includes(newInput.toLowerCase()))
-      .splice(0, 8);
-    setOptions(degreeOptions);
+    const degreeOptions = Object.keys(allDegrees);
+    console.log(`degreeOptions: ${degreeOptions}`);
+
+    const afterCombine = degreeOptions
+      .map((code) => `${code} ${allDegrees[code]}`);
+    console.log(`afterCombine: ${afterCombine}`);
+
+    const afterDistancce = afterCombine
+      .map((title) => {
+        return {
+          'distance': levenshteinEditDistance(newInput, title),
+          'name': title
+        }
+      });
+    console.log(`afterDistancce: ${afterDistancce}`);
+
+    afterDistancce.sort((a, b) => a.distance - b.distance);
+    const afterSort = afterDistancce;
+    console.log(`afterSort: ${afterSort}`);
+
+    const afterSplice = afterSort.splice(0, 10);
+    console.log(`afterSplice: ${afterSplice}`);
+
+    const afterMap = afterSplice.map(pair => pair.name);
+    console.log(`afterMap: ${afterMap}`);
+
+    setOptions(afterMap);
   };
 
   const props = useSpring(springProps);


### PR DESCRIPTION
- in setup, degree is now fuzzily searched
- no longer need to type *exact* degree
- fuzz is weighted by what's effectively a normalised version of levenstein distance
- in cases of equal weighting (usualyl when both have a weight of 1), uses string len as tie breaker
- only gives user the 8 most relevant results

<img width="1521" alt="image" src="https://github.com/csesoc/circles/assets/93496985/3f38de20-63a0-41b6-ad10-476e032ee59f">
