### PR TITLE
fix(degree wizard): remove dispatch & fix requests

### DIFF
--- a/frontend/src/pages/DegreeWizard/YearStep/YearStep.tsx
+++ b/frontend/src/pages/DegreeWizard/YearStep/YearStep.tsx
@@ -6,7 +6,6 @@ import axios from 'axios';
 import openNotification from 'utils/openNotification';
 import Spinner from 'components/Spinner';
 import { RootState } from 'config/store';
-import { useAppDispatch } from 'hooks';
 import springProps from '../common/spring';
 import Steps from '../common/steps';
 import CS from '../common/styles';
@@ -22,7 +21,6 @@ type Props = {
 
 const YearStep = ({ incrementStep }: Props) => {
   const props = useSpring(springProps);
-  const dispatch = useAppDispatch();
   const { token } = useSelector((state: RootState) => state.settings);
 
   return (
@@ -44,12 +42,13 @@ const YearStep = ({ incrementStep }: Props) => {
               const numYears = parseInt(endYear, 10) - startYearInt + 1;
               // We can trust num years to be a valid number because the range picker only allows valid ranges
               try {
-                await axios.put('/user/updateDegreeLength', { numYears }, { params: { token } });
-                await axios.put(
-                  '/user/updateStartYear',
-                  { startYear: startYearInt },
-                  { params: { token } }
-                );
+                await axios.put('/user/updateDegreeLength', null, { params: { numYears, token } });
+                await axios.put('/user/updateStartYear', null, {
+                  params: {
+                    startYear: startYearInt,
+                    token
+                  }
+                });
               } catch {
                 openNotification({
                   type: 'error',


### PR DESCRIPTION
fixing up degree step for frontend year step requests to work

fe requests not following the same format as what we had in our fastapi - the backend requires params for the put request but we had a mix of params and body args.
```
@router.put("/updateStartYear")
def update_start_year(startYear: int, token: str = DUMMY_TOKEN):
...
```