### PR TITLE
feat(graphical-selector): move graphical selector to use reactQuery and backend user data

### DIFF
--- a/backend/algorithms/objects/user.py
+++ b/backend/algorithms/objects/user.py
@@ -79,7 +79,10 @@ class User:
 
     def has_taken_course(self, course: str):
         """ Determines if the user has taken this course """
-        return any(c in self.courses and (self.courses[c][1] or 50) >= 50 for c in chain([course], (CACHED_EQUIVALENTS.get(course) or [])))
+        return any(
+            c in self.courses and (self.courses[c][1] or 50) >= 50 
+            for c in chain([course], (CACHED_EQUIVALENTS.get(course) or []))
+        )
 
     def is_taking_course(self, course: str):
         """ Determines if the user is taking this course this term """

--- a/backend/server/routers/courses.py
+++ b/backend/server/routers/courses.py
@@ -268,6 +268,7 @@ def regex_search(search_string: str) -> Mapping[str, str]:
             },
         },
     },
+    deprecated=True
 )
 def get_all_unlocked(userData: UserData) -> Dict[str, Dict]:
     """

--- a/backend/server/routers/user.py
+++ b/backend/server/routers/user.py
@@ -397,14 +397,15 @@ def unlocked_courses(token: str = DUMMY_TOKEN) -> CoursesState:
     """
     token_user = get_user(token)
     user = storage_to_user(get_user(token))
+    # TODO: remove
     print("\n\nUNLOCKED USER")
     print(token_user['courses'])
     print(user.courses)
     print(user.has_taken_course("COMP1511"))
     print("\n")
     courses_state: dict[str, CourseState] = {}
-    # user = User(fix_user_data())
     for course, condition in CONDITIONS.items():
+        # TODO: check if this is still correct, taken from old route
         result, warnings = condition.validate(user) if condition is not None else (True, [])
         if result:
             courses_state[course] = CourseState(
@@ -426,11 +427,3 @@ def setup_example_user(token: str = DUMMY_TOKEN):
     update_start_year(2021, token)
     update_degree_length(4, token)
     setIsComplete(False, token)
-    
-# @router.post("/planSomeCoursesDEBUG")
-# def plan_some_courses(token: str = DUMMY_TOKEN):
-#     add_to_unplanned(CourseCode(courseCode="COMP1511"), token)
-#     add_to_unplanned(CourseCode(courseCode="COMP1521"), token)
-#     add_to_unplanned(CourseCode(courseCode="COMP1531"), token)
-#     add_to_unplanned(CourseCode(courseCode="COMP2521"), token)
-

--- a/backend/server/routers/user.py
+++ b/backend/server/routers/user.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 from bson.objectid import ObjectId
 from algorithms.objects.user import User
+from server.routers.utility import get_core_courses
 from server.routers.courses import get_course
 from data.config import LIVE_YEAR
 from fastapi import APIRouter, HTTPException
@@ -361,8 +362,7 @@ def storage_to_user(user: Storage) -> User:
     res.year = user['planner']['startYear']
     res.specialisations = user['degree']['specs']
     res.add_courses(storage_courses_to_user_courses(user['courses']))
-    # res.cur_courses = ?  # TODO: fix these
-    # res.core_courses = ?
+    res.core_courses = get_core_courses(user['degree']['programCode'], user['degree']['specs'])
 
     return res
 

--- a/backend/server/routers/user.py
+++ b/backend/server/routers/user.py
@@ -1,28 +1,17 @@
 from itertools import chain
-<<<<<<< HEAD
-from typing import Dict, Optional, Tuple, cast
-=======
-import itertools
-from pprint import pprint
+from typing import Optional, Tuple, cast
 from typing import Any, cast
->>>>>>> CIRCLES-331/user-data-to-backend
 
 from bson.objectid import ObjectId
-<<<<<<< HEAD
 from algorithms.objects.user import User
 from server.routers.courses import get_course
 from data.config import LIVE_YEAR
-=======
->>>>>>> CIRCLES-331/user-data-to-backend
 from fastapi import APIRouter, HTTPException
 import pydantic
 
 from data.config import LIVE_YEAR
 from server.config import DUMMY_TOKEN
-<<<<<<< HEAD
-from server.routers.model import CACHED_HANDBOOK_NOTE, CONDITIONS, CourseCode, CourseMark, CourseState, CoursesState, CoursesStorage, DegreeLocalStorage, LocalStorage, PlannerData, PlannerLocalStorage, Storage
-=======
->>>>>>> CIRCLES-331/user-data-to-backend
+from server.routers.model import CACHED_HANDBOOK_NOTE, CONDITIONS, CourseMark, CourseState, CoursesState, CoursesStorage, DegreeLocalStorage, LocalStorage, PlannerLocalStorage, Storage
 from server.database import usersDB
 from server.routers.model import (
     CourseMark,

--- a/frontend/src/pages/GraphicalSelector/CourseGraph/CourseGraph.tsx
+++ b/frontend/src/pages/GraphicalSelector/CourseGraph/CourseGraph.tsx
@@ -79,6 +79,9 @@ const CourseGraph = ({ onNodeClick, handleToggleFullscreen, fullscreen, focused 
   console.log('planner query', plannerQuery);
   const planner: PlannerResponse = plannerQuery.isSuccess ? plannerQuery.data : DUMMYPLANNER;
 
+  // TODO: make a non success handler
+  const queriesSuccess = degreeQuery.isSuccess && plannerQuery.isSuccess;
+
   const { courses: plannedCourses } = planner;
   const { programCode, specs } = degree;
 
@@ -183,6 +186,7 @@ const CourseGraph = ({ onNodeClick, handleToggleFullscreen, fullscreen, focused 
     };
 
     const setupGraph = async () => {
+      console.log('setting up graph');
       try {
         const res = await axios.get<GraphPayload>(
           `/programs/graph/${programCode}/${specs.join('+')}`
@@ -195,8 +199,8 @@ const CourseGraph = ({ onNodeClick, handleToggleFullscreen, fullscreen, focused 
       }
     };
 
-    if (!graphRef.current) setupGraph();
-  }, [onNodeClick, oldPlannedCourses, programCode, specs]);
+    if (!graphRef.current && queriesSuccess) setupGraph();
+  }, [onNodeClick, oldPlannedCourses, programCode, specs, queriesSuccess]);
 
   const showAllCourses = () => {
     if (!graphRef.current) return;
@@ -277,7 +281,7 @@ const CourseGraph = ({ onNodeClick, handleToggleFullscreen, fullscreen, focused 
   useEffect(() => {
     if (unlockedCourses) showUnlockedCourses();
     else showAllCourses();
-  }, [planner.courses, showUnlockedCourses, unlockedCourses]);
+  }, [oldPlanner.courses, showUnlockedCourses, unlockedCourses]);
 
   return (
     <S.Wrapper ref={containerRef}>

--- a/frontend/src/pages/GraphicalSelector/CourseGraph/CourseGraph.tsx
+++ b/frontend/src/pages/GraphicalSelector/CourseGraph/CourseGraph.tsx
@@ -23,7 +23,7 @@ import { useAppWindowSize } from 'hooks';
 import { ZOOM_IN_RATIO, ZOOM_OUT_RATIO } from '../constants';
 import { defaultEdge, defaultNode, mapNodeStyle, nodeStateStyles } from './graph';
 import S from './styles';
-import { getUserDegree, getUserPlanner } from 'utils/api/userApi';
+import { getUser, getUserDegree, getUserPlanner } from 'utils/api/userApi';
 import { useQuery } from 'react-query';
 import { parseMarkToInt } from 'pages/TermPlanner/utils';
 
@@ -111,6 +111,14 @@ const CourseGraph = ({ onNodeClick, handleToggleFullscreen, fullscreen, focused 
   const { programCode, specs } = degree;
 
   useEffect(() => {
+    const temp = async () => {
+      console.log('token:', getToken());
+      console.log('userdata:', await getUser());
+    };
+    temp();
+  }, [degree, planner, plannedCourses]);
+
+  useEffect(() => {
     // courses is a list of course codes
     const initialiseGraph = async (courses: string[], courseEdges: CourseEdge[]) => {
       const container = containerRef.current;
@@ -148,6 +156,7 @@ const CourseGraph = ({ onNodeClick, handleToggleFullscreen, fullscreen, focused 
       graphRef.current = new Graph(graphArgs);
 
       const data = {
+        // TODO: the courses do not get added to the right section on addtounplanned
         nodes: courses.map((c) => mapNodeStyle(c, plannedCourses)),
         edges: courseEdges
       };
@@ -204,6 +213,7 @@ const CourseGraph = ({ onNodeClick, handleToggleFullscreen, fullscreen, focused 
         '/courses/getAllUnlocked/',
         JSON.stringify(prepareUserPayload(degree, planner))
       );
+      console.log('unlocked', coursesStates);
       graphRef.current.getNodes().forEach((n) => {
         const id = n.getID();
         if (coursesStates[id]?.unlocked) {

--- a/frontend/src/pages/GraphicalSelector/CourseGraph/CourseGraph.tsx
+++ b/frontend/src/pages/GraphicalSelector/CourseGraph/CourseGraph.tsx
@@ -63,7 +63,6 @@ const CourseGraph = ({ onNodeClick, handleToggleFullscreen, fullscreen, focused 
     ? programGraphQuery.data
     : DUMMYGRAPH;
 
-  // TODO: make a non success handler
   const queriesSuccess =
     degreeQuery.isSuccess && coursesQuery.isSuccess && programGraphQuery.isSuccess;
 
@@ -212,7 +211,7 @@ const CourseGraph = ({ onNodeClick, handleToggleFullscreen, fullscreen, focused 
 
   return (
     <S.Wrapper ref={containerRef}>
-      {loading ? (
+      {loading && queriesSuccess ? (
         <S.SpinnerWrapper>
           <Spinner text="Loading graph..." />
         </S.SpinnerWrapper>

--- a/frontend/src/pages/GraphicalSelector/CourseGraph/graph.ts
+++ b/frontend/src/pages/GraphicalSelector/CourseGraph/graph.ts
@@ -1,5 +1,5 @@
 import type { Arrow } from '@antv/g6';
-import { PlannerCourse } from 'types/planner';
+import { CourseResponse } from 'types/userResponse';
 
 export const defaultNode = {
   size: 70,
@@ -28,7 +28,10 @@ export const defaultEdge = (arrow: typeof Arrow) => ({
 });
 
 // plannedCourses is an object of with keys of courseCodes
-export const mapNodeStyle = (courseCode: string, plannedCourses: Record<string, PlannerCourse>) => {
+export const mapNodeStyle = (
+  courseCode: string,
+  plannedCourses: Record<string, CourseResponse>
+) => {
   // determine if planned or unplanned
   if (plannedCourses[courseCode]) {
     // uses default node style

--- a/frontend/src/types/userResponse.ts
+++ b/frontend/src/types/userResponse.ts
@@ -28,14 +28,14 @@ export type PlannerResponse = {
 };
 
 export type Term = {
-  y: string;
-  t: string;
+  Y: string;
+  T: string;
 };
 
 // null coalesced to remove `undefined`. This SHOULD NOT see production
 // temp fix while we wait for `prepareUserPayload` to be deprecated
 export const badPlanner = {
-  mostRecentPastTerm: { y: '2020', t: '2' },
+  mostRecentPastTerm: { Y: '2020', T: '2' },
   unplanned: [],
   startYear: 2021,
   isSummerEnabled: false,

--- a/frontend/src/types/userResponse.ts
+++ b/frontend/src/types/userResponse.ts
@@ -11,6 +11,8 @@ export type DegreeResponse = {
   isComplete: boolean;
 };
 
+export type CoursesResponse = Record<string, CourseResponse>;
+
 export type CourseResponse = {
   code: string;
   suppress: boolean;

--- a/frontend/src/utils/api/degreeApi.ts
+++ b/frontend/src/utils/api/degreeApi.ts
@@ -27,7 +27,7 @@ export const setupDegreeWizard = async (wizard: DegreeWizardPayload) => {
 
 export const handleDegreeChange = async ({ programCode }: { programCode: string }) => {
   const token = await getToken();
-  resetDegree();
+  await resetDegree();
   try {
     await axios.put('user/setProgram', null, {
       params: { programCode: programCode.substring(0, 4), token }

--- a/frontend/src/utils/api/programsApi.ts
+++ b/frontend/src/utils/api/programsApi.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { GraphPayload } from 'types/api';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getProgramGraph = async (
+  programCode: string,
+  specs: string[]
+): Promise<GraphPayload> => {
+  const res = await axios.get(`/programs/graph/${programCode}/${specs.join('+')}`);
+  return res.data as GraphPayload;
+};

--- a/frontend/src/utils/api/userApi.ts
+++ b/frontend/src/utils/api/userApi.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { getStoredState } from 'redux-persist';
 import { CoursesAllUnlocked } from 'types/api';
-import { CourseResponse, DegreeResponse, PlannerResponse, UserResponse } from 'types/userResponse';
+import { CoursesResponse, DegreeResponse, PlannerResponse, UserResponse } from 'types/userResponse';
 import { persistConfig, RootState } from 'config/store';
 
 // export const getToken = (): string => useSelector((state: RootState) => state.settings.token);
@@ -31,10 +31,10 @@ export const getUserPlanner = async (): Promise<PlannerResponse> => {
   return planner.data as PlannerResponse;
 };
 
-export const getUserCourses = async (): Promise<CourseResponse> => {
+export const getUserCourses = async (): Promise<CoursesResponse> => {
   const token = await getToken();
   const courses = await axios.get(`user/data/courses/${token}`);
-  return courses.data as CourseResponse;
+  return courses.data as CoursesResponse;
 };
 
 export const getUsersUnlockedCourses = async (): Promise<CoursesAllUnlocked> => {

--- a/frontend/src/utils/api/userApi.ts
+++ b/frontend/src/utils/api/userApi.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { getStoredState } from 'redux-persist';
+import { CoursesAllUnlocked } from 'types/api';
 import { CourseResponse, DegreeResponse, PlannerResponse, UserResponse } from 'types/userResponse';
 import { persistConfig, RootState } from 'config/store';
 
@@ -34,4 +35,10 @@ export const getUserCourses = async (): Promise<CourseResponse> => {
   const token = await getToken();
   const courses = await axios.get(`user/data/courses/${token}`);
   return courses.data as CourseResponse;
+};
+
+export const getUsersUnlockedCourses = async (): Promise<CoursesAllUnlocked> => {
+  const token = await getToken();
+  const unlocked = await axios.get(`user/unlockedCourses/${token}`);
+  return unlocked.data as CoursesAllUnlocked;
 };


### PR DESCRIPTION
I wanna say this is done. 🤯 

Moved the graphical selector over to useQuery. 

To do so:
- Created a new query key 'graph' for the graph structure. This should never really get invalidated as this would require the handbook to change.
- deprecated old /courses/getAllUnlocked route.
- created new /user/unlockedCourses/{token} route.
- created functions to convert the storage user into a algorithm user for this.
- cleaned up the CourseGraph.tsx file a little bit more.
- decided to keep old /programs/graph/{code}/{specs} route since i wanted to have the degree anyway for effect dependencies, and graph structures arent user unique. It keeps it open for future ideas (that have been brought up in the past) of being able to have multiple 'tabs' of graphs on the graphicalSelector page, for different degrees and what not. 
- also fixed some typing.

i love you 💛 

p.s.
if you want to test this out, you will need to change `/addToUnplanned` to put courses into the user['courses'] dictionary as well. 