### PR TITLE
Update Tiktok Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ We are a team that is part of DevSoc! See [TEAM.md](./TEAM.md) for more informat
 
 Also, special thanks to James Ji, Vincent Xiao, Hayes Choy for being the first team to work on and inspire Circles :)
 
-[For further development documentation, visit our confluence page!](https://devsoc.atlassian.net/wiki/spaces/C/pages/756966/About+Circles)
+Information to run Circles on your local machine are available in the [frontend](./frontend/README.md) and [backend](./backend/README.md) `README.md` files. For further development documentation, visit our [confluence page](https://devsoc.atlassian.net/wiki/spaces/C/pages/756966/About+Circles)!

--- a/README.md
+++ b/README.md
@@ -47,4 +47,6 @@ We are a team that is part of DevSoc! See [TEAM.md](./TEAM.md) for more informat
 
 Also, special thanks to James Ji, Vincent Xiao, Hayes Choy for being the first team to work on and inspire Circles :)
 
-Information to run Circles on your local machine are available in the [frontend](./frontend/README.md) and [backend](./backend/README.md) `README.md` files. For further development documentation, visit our [confluence page](https://devsoc.atlassian.net/wiki/spaces/C/pages/756966/About+Circles)!
+Information to run Circles on your local machine are available in the [frontend](./frontend/README.md) and [backend](./backend/README.md) `README.md` files.
+
+For further development documentation, visit our [confluence page](https://devsoc.atlassian.net/wiki/spaces/C/pages/756966/About+Circles)!

--- a/frontend/src/pages/LandingPage/SponsorSection/SponsorSection.tsx
+++ b/frontend/src/pages/LandingPage/SponsorSection/SponsorSection.tsx
@@ -17,7 +17,7 @@ const SponsorSection = () => (
     <S.SponsorsText>Our sponsors</S.SponsorsText>
     <S.LogosWrapper>
       <Logo href="https://www.janestreet.com" src={janestreetLogo} />
-      <Logo href="https://www.tiktok.com" src={tiktokLogo} />
+      <Logo href="https://careers.tiktok.com/" src={tiktokLogo} />
     </S.LogosWrapper>
   </PageContainer>
 );

--- a/frontend/src/pages/LandingPage/SponsorSection/SponsorSection.tsx
+++ b/frontend/src/pages/LandingPage/SponsorSection/SponsorSection.tsx
@@ -17,7 +17,7 @@ const SponsorSection = () => (
     <S.SponsorsText>Our sponsors</S.SponsorsText>
     <S.LogosWrapper>
       <Logo href="https://www.janestreet.com" src={janestreetLogo} />
-      <Logo href="https://careers.tiktok.com/" src={tiktokLogo} />
+      <Logo href="https://careers.tiktok.com" src={tiktokLogo} />
     </S.LogosWrapper>
   </PageContainer>
 );


### PR DESCRIPTION
- Changed the Tiktok hyperlink to link to the [careers page](https://careers.tiktok.com/) rather than the standard [for you page](https://www.tiktok.com/).
- Added link to installation instructions on home page of projects `README.md`