### PR TITLE
feat(frontend): bump antd icons version to 5.3.7

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/colors": "7.0.2",
-        "@ant-design/icons": "5.3.0",
+        "@ant-design/icons": "5.3.6",
         "@ant-design/plots": "2.1.15",
         "@antv/algorithm": "0.1.26",
         "@antv/g6": "4.8.24",
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.3.0.tgz",
-      "integrity": "sha512-69FgBsIkeCjw72ZU3fJpqjhmLCPrzKGEllbrAZK7MUdt1BrKsyG6A8YDCBPKea27UQ0tRXi33PcjR4tp/tEXMg==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.3.6.tgz",
+      "integrity": "sha512-JeWsgNjvkTTC73YDPgWOgdScRku/iHN9JU0qk39OSEmJSCiRghQMLlxGTCY5ovbRRoXjxHXnUKgQEgBDnQfKmA==",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
         "@ant-design/icons-svg": "^4.4.0",
@@ -4075,25 +4075,6 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/antd/node_modules/@ant-design/icons": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.3.5.tgz",
-      "integrity": "sha512-Vyv/OsKz56BsKBtcRlLP6G8RGaRW43f7G5dK3XNPCaeV4YyehLVaITuNKi2YJG9hMVURkBdzdGhveNQlnKTFqw==",
-      "dependencies": {
-        "@ant-design/colors": "^7.0.0",
-        "@ant-design/icons-svg": "^4.4.0",
-        "@babel/runtime": "^7.11.2",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.31.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/anymatch": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/colors": "7.0.2",
-        "@ant-design/icons": "5.3.6",
+        "@ant-design/icons": "5.3.7",
         "@ant-design/plots": "2.1.15",
         "@antv/algorithm": "0.1.26",
         "@antv/g6": "4.8.24",
@@ -56,7 +56,6 @@
         "@types/react-helmet": "6.1.11",
         "@types/react-scroll": "1.8.10",
         "@types/styled-components": "5.1.34",
-        "@types/testing-library__jest-dom": "6.0.0",
         "@types/uuid": "9.0.8",
         "@typescript-eslint/eslint-plugin": "7.3.1",
         "@typescript-eslint/parser": "7.3.1",
@@ -150,9 +149,9 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.3.6.tgz",
-      "integrity": "sha512-JeWsgNjvkTTC73YDPgWOgdScRku/iHN9JU0qk39OSEmJSCiRghQMLlxGTCY5ovbRRoXjxHXnUKgQEgBDnQfKmA==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.3.7.tgz",
+      "integrity": "sha512-bCPXTAg66f5bdccM4TT21SQBDO1Ek2gho9h3nO9DAKXJP4sq+5VBjrQMSxMVXSB3HyEz+cUbHQ5+6ogxCOpaew==",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
         "@ant-design/icons-svg": "^4.4.0",
@@ -3391,16 +3390,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw=="
-    },
-    "node_modules/@types/testing-library__jest-dom": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-6.0.0.tgz",
-      "integrity": "sha512-bnreXCgus6IIadyHNlN/oI5FfX4dWgvGhOPvpr7zzCYDGAPIfvyIoAozMBINmhmsVuqV0cncejF2y5KC7ScqOg==",
-      "deprecated": "This is a stub types definition. @testing-library/jest-dom provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "@testing-library/jest-dom": "*"
-      }
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@ant-design/colors": "7.0.2",
-    "@ant-design/icons": "5.3.6",
+    "@ant-design/icons": "5.3.7",
     "@ant-design/plots": "2.1.15",
     "@antv/algorithm": "0.1.26",
     "@antv/g6": "4.8.24",
@@ -83,7 +83,6 @@
     "@types/react-helmet": "6.1.11",
     "@types/react-scroll": "1.8.10",
     "@types/styled-components": "5.1.34",
-    "@types/testing-library__jest-dom": "6.0.0",
     "@types/uuid": "9.0.8",
     "@typescript-eslint/eslint-plugin": "7.3.1",
     "@typescript-eslint/parser": "7.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "@ant-design/colors": "7.0.2",
-    "@ant-design/icons": "5.3.0",
+    "@ant-design/icons": "5.3.6",
     "@ant-design/plots": "2.1.15",
     "@antv/algorithm": "0.1.26",
     "@antv/g6": "4.8.24",


### PR DESCRIPTION
- allows new package-lock file to be generated as there were issues with current subdependencies
- https://github.com/ant-design/ant-design-icons/issues/470#issuecomment-2041784963
- also removed unneeded types package