### PR TITLE
Feat/fe/quick course add button in search

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "antd": "5.15.4",
         "axios": "1.6.8",
         "dayjs": "1.11.10",
-        "fast-fuzzy": "^1.12.0",
+        "fast-fuzzy": "1.12.0",
         "framer-motion": "11.0.20",
         "jwt-decode": "4.0.0",
         "rc-picker": "4.3.0",
@@ -8151,11 +8151,6 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    }
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "antd": "5.15.4",
     "axios": "1.6.8",
     "dayjs": "1.11.10",
-    "fast-fuzzy": "^1.12.0",
+    "fast-fuzzy": "1.12.0",
     "framer-motion": "11.0.20",
     "jwt-decode": "4.0.0",
     "rc-picker": "4.3.0",

--- a/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
+++ b/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 const CourseSearchBar = ({ onSelectCallback, style }: Props) => {
   const [value, setValue] = useState<string | null>(null);
-  const [courses, setCourses] = useState<{ label: string; value: string }[]>([]);
+  const [courses, setCourses] = useState<Array<{ label: string; value: string }>>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [debouncedSearchTerm] = useDebounce(value, 200);
 

--- a/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
+++ b/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
@@ -21,13 +21,13 @@ const SearchResultLabel = ({
   runMutate,
   isPlanned
 }: SearchResultLabelProps) => {
+  const codeAndTitleText = `${courseCode}: ${courseTitle}`;
+
   return (
-    <div>
+    <div title={codeAndTitleText}>
       <QuickAddCartButton courseCode={courseCode} runMutate={runMutate} planned={isPlanned} />
-      <span style={{ 'marginLeft': '1ch' }}>
-        {courseCode}: {courseTitle}
-      </span>
-    </div >
+      <span style={{ marginLeft: '1ch' }}> {codeAndTitleText} </span>
+    </div>
   );
 };
 

--- a/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
+++ b/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Select, Spin } from 'antd';
+import { Select, Spin, Typography } from 'antd';
 import { SearchCourse } from 'types/api';
 import { CoursesResponse } from 'types/userResponse';
 import { useDebounce } from 'use-debounce';
@@ -24,9 +24,16 @@ const SearchResultLabel = ({
   const codeAndTitleText = `${courseCode}: ${courseTitle}`;
 
   return (
-    <div title={codeAndTitleText}>
+    <div
+      style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem' }}
+      title={codeAndTitleText}
+    >
+      <div style={{ overflow: 'hidden' }}>
+        <Typography.Text style={{ maxWidth: '100%' }} ellipsis>
+          {codeAndTitleText}
+        </Typography.Text>
+      </div>
       <QuickAddCartButton courseCode={courseCode} runMutate={runMutate} planned={isPlanned} />
-      <span style={{ marginLeft: '1ch' }}> {codeAndTitleText} </span>
     </div>
   );
 };

--- a/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
+++ b/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Select, Spin, Typography } from 'antd';
+import { Flex, Select, Spin, Typography } from 'antd';
 import { SearchCourse } from 'types/api';
 import { CoursesResponse } from 'types/userResponse';
 import { useDebounce } from 'use-debounce';
@@ -24,17 +24,12 @@ const SearchResultLabel = ({
   const codeAndTitleText = `${courseCode}: ${courseTitle}`;
 
   return (
-    <div
-      style={{ display: 'flex', justifyContent: 'space-between', gap: '0.5rem' }}
-      title={codeAndTitleText}
-    >
+    <Flex justify="space-between" gap="0.5rem" title={codeAndTitleText}>
       <div style={{ overflow: 'hidden' }}>
-        <Typography.Text style={{ maxWidth: '100%' }} ellipsis>
-          {codeAndTitleText}
-        </Typography.Text>
+        <Typography.Text ellipsis>{codeAndTitleText}</Typography.Text>
       </div>
       <QuickAddCartButton courseCode={courseCode} runMutate={runMutate} planned={isPlanned} />
-    </div>
+    </Flex>
   );
 };
 

--- a/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
+++ b/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
@@ -15,6 +15,7 @@ type SearchResultLabelProps = {
   runMutate?: (courseId: string) => void;
 };
 
+/* eslint-disable */
 const SearchResultLabel = ({
   courseCode,
   courseTitle,
@@ -24,8 +25,10 @@ const SearchResultLabel = ({
   return (
     <div>
       <QuickAddCartButton courseCode={courseCode} runMutate={runMutate} planned={isPlanned} />
-      {courseCode}: {courseTitle}
-    </div>
+      <span style={{ 'marginLeft': '1ch' }}>
+        {courseCode}: {courseTitle}
+      </span>
+    </div >
   );
 };
 
@@ -111,7 +114,7 @@ const CourseSearchBar = ({ onSelectCallback, style, userCourses }: CourseSearchB
       onSearch={handleSearch}
       onSelect={handleSelect}
       notFoundContent={isLoading && value && <Spin size="small" />}
-      style={{ width: '30rem', ...style }}
+      style={{ width: '55ch', ...style }}
       suffixIcon={!value}
       className="course-search-bar"
     />

--- a/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
+++ b/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
@@ -28,12 +28,13 @@ const SearchResultLabel = ({ courseCode, courseTitle, runMutate, isPlanned }: Se
 type CourseSearchBarProps = {
   onSelectCallback: (courseCode: string) => void;
   style?: React.CSSProperties;
+  // TODO: planner not required here
   planner?: PlannerResponse;
   userCourses?: CoursesResponse;
 };
 
 
-const CourseSearchBar = ({ onSelectCallback, style, planner: _, userCourses }: CourseSearchBarProps) => {
+const CourseSearchBar = ({ onSelectCallback, style, userCourses }: CourseSearchBarProps) => {
   const [value, setValue] = useState<string | null>(null);
   const [searchResults, setSearchResults] = useState<SearchCourse>({});
   const [isLoading, setIsLoading] = useState(false);

--- a/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
+++ b/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
@@ -1,29 +1,79 @@
+/* eslint-disable */
 import React, { useEffect, useState } from 'react';
 import { Select, Spin } from 'antd';
+import { CoursesResponse, PlannerResponse } from 'types/userResponse';
 import { useDebounce } from 'use-debounce';
 import { searchCourse } from 'utils/api/courseApi';
+import QuickAddCartButton from 'components/QuickAddCartButton';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { addToUnplanned, removeCourse } from 'utils/api/plannerApi';
+import { SearchCourse } from 'types/api';
 
-type Props = {
-  onSelectCallback: (courseCode: string) => void;
-  style?: React.CSSProperties;
+type SearchResultLabelProps = {
+  courseCode: string;
+  courseTitle: string;
+  isPlanned: boolean;
+  runMutate?: (courseId: string) => void;
 };
 
-const CourseSearchBar = ({ onSelectCallback, style }: Props) => {
+const SearchResultLabel = ({ courseCode, courseTitle, runMutate, isPlanned }: SearchResultLabelProps) => {
+  return (
+    <div>
+      <QuickAddCartButton courseCode={courseCode} runMutate={runMutate} planned={isPlanned} />
+      {courseCode}: {courseTitle}
+    </div>
+  );
+}
+
+type CourseSearchBarProps = {
+  onSelectCallback: (courseCode: string) => void;
+  style?: React.CSSProperties;
+  planner?: PlannerResponse;
+  userCourses?: CoursesResponse;
+};
+
+
+const CourseSearchBar = ({ onSelectCallback, style, planner: _, userCourses }: CourseSearchBarProps) => {
   const [value, setValue] = useState<string | null>(null);
-  const [courses, setCourses] = useState<Array<{ label: string; value: string }>>([]);
+  const [searchResults, setSearchResults] = useState<SearchCourse>({});
   const [isLoading, setIsLoading] = useState(false);
   const [debouncedSearchTerm] = useDebounce(value, 200);
+
+  const isInPlanner = (courseCode: string) => (
+    userCourses !== undefined
+    && userCourses[courseCode] !== undefined
+    && userCourses[courseCode].plannedFor !== null
+  );
+
+  const queryClient = useQueryClient();
+  const courseMutation = useMutation({
+    mutationFn: async (courseId: string) => {
+      const handleMutation = isInPlanner(courseId) ? removeCourse : addToUnplanned;
+      await handleMutation(courseId);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['courses'] });
+      await queryClient.invalidateQueries({ queryKey: ['planner'] });
+    }
+  });
+
+
+  const courses =
+    Object.entries(searchResults).map(([courseCode, courseTitle]) => ({
+      label: <SearchResultLabel
+        courseCode={courseCode}
+        courseTitle={courseTitle}
+        isPlanned={isInPlanner(courseCode)}
+        runMutate={courseMutation.mutate}
+      />,
+      value: courseCode
+    }));
 
   useEffect(() => {
     const handleSearchCourse = async (query: string) => {
       try {
-        const res = await searchCourse(query);
-        setCourses(
-          Object.keys(res).map((course) => ({
-            label: `${course}: ${res[course]}`,
-            value: course
-          }))
-        );
+        const searchResults = await searchCourse(query);
+        setSearchResults(searchResults);
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error('Error at handleSearchCourse: ', err);
@@ -44,7 +94,6 @@ const CourseSearchBar = ({ onSelectCallback, style }: Props) => {
 
   const handleSearch = (courseCode: string) => {
     setValue(courseCode);
-    setCourses([]);
     setIsLoading(true);
   };
 

--- a/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
+++ b/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
@@ -15,7 +15,6 @@ type SearchResultLabelProps = {
   runMutate?: (courseId: string) => void;
 };
 
-/* eslint-disable */
 const SearchResultLabel = ({
   courseCode,
   courseTitle,

--- a/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
+++ b/frontend/src/components/CourseSearchBar/CourseSearchBar.tsx
@@ -1,13 +1,12 @@
-/* eslint-disable */
 import React, { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Select, Spin } from 'antd';
-import { CoursesResponse, PlannerResponse } from 'types/userResponse';
+import { SearchCourse } from 'types/api';
+import { CoursesResponse } from 'types/userResponse';
 import { useDebounce } from 'use-debounce';
 import { searchCourse } from 'utils/api/courseApi';
-import QuickAddCartButton from 'components/QuickAddCartButton';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { addToUnplanned, removeCourse } from 'utils/api/plannerApi';
-import { SearchCourse } from 'types/api';
+import QuickAddCartButton from 'components/QuickAddCartButton';
 
 type SearchResultLabelProps = {
   courseCode: string;
@@ -16,23 +15,25 @@ type SearchResultLabelProps = {
   runMutate?: (courseId: string) => void;
 };
 
-const SearchResultLabel = ({ courseCode, courseTitle, runMutate, isPlanned }: SearchResultLabelProps) => {
+const SearchResultLabel = ({
+  courseCode,
+  courseTitle,
+  runMutate,
+  isPlanned
+}: SearchResultLabelProps) => {
   return (
     <div>
       <QuickAddCartButton courseCode={courseCode} runMutate={runMutate} planned={isPlanned} />
       {courseCode}: {courseTitle}
     </div>
   );
-}
+};
 
 type CourseSearchBarProps = {
   onSelectCallback: (courseCode: string) => void;
   style?: React.CSSProperties;
-  // TODO: planner not required here
-  planner?: PlannerResponse;
   userCourses?: CoursesResponse;
 };
-
 
 const CourseSearchBar = ({ onSelectCallback, style, userCourses }: CourseSearchBarProps) => {
   const [value, setValue] = useState<string | null>(null);
@@ -40,11 +41,10 @@ const CourseSearchBar = ({ onSelectCallback, style, userCourses }: CourseSearchB
   const [isLoading, setIsLoading] = useState(false);
   const [debouncedSearchTerm] = useDebounce(value, 200);
 
-  const isInPlanner = (courseCode: string) => (
-    userCourses !== undefined
-    && userCourses[courseCode] !== undefined
-    && userCourses[courseCode].plannedFor !== null
-  );
+  const isInPlanner = (courseCode: string) =>
+    userCourses !== undefined &&
+    userCourses[courseCode] !== undefined &&
+    userCourses[courseCode].plannedFor !== null;
 
   const queryClient = useQueryClient();
   const courseMutation = useMutation({
@@ -58,23 +58,22 @@ const CourseSearchBar = ({ onSelectCallback, style, userCourses }: CourseSearchB
     }
   });
 
-
-  const courses =
-    Object.entries(searchResults).map(([courseCode, courseTitle]) => ({
-      label: <SearchResultLabel
+  const courses = Object.entries(searchResults).map(([courseCode, courseTitle]) => ({
+    label: (
+      <SearchResultLabel
         courseCode={courseCode}
         courseTitle={courseTitle}
         isPlanned={isInPlanner(courseCode)}
         runMutate={courseMutation.mutate}
-      />,
-      value: courseCode
-    }));
+      />
+    ),
+    value: courseCode
+  }));
 
   useEffect(() => {
     const handleSearchCourse = async (query: string) => {
       try {
-        const searchResults = await searchCourse(query);
-        setSearchResults(searchResults);
+        setSearchResults(await searchCourse(query));
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error('Error at handleSearchCourse: ', err);

--- a/frontend/src/pages/CourseSelector/CourseBanner/CourseBanner.tsx
+++ b/frontend/src/pages/CourseSelector/CourseBanner/CourseBanner.tsx
@@ -1,14 +1,13 @@
-/* eslint-disable */
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Typography } from 'antd';
+import { CoursesResponse } from 'types/userResponse';
 import { fetchAllDegrees } from 'utils/api/programApi';
 import { getUserDegree } from 'utils/api/userApi';
 import CourseSearchBar from 'components/CourseSearchBar';
 import { useAppDispatch } from 'hooks';
 import { addTab } from 'reducers/courseTabsSlice';
 import S from './styles';
-import { CoursesResponse } from 'types/userResponse';
 
 const { Title } = Typography;
 

--- a/frontend/src/pages/CourseSelector/CourseBanner/CourseBanner.tsx
+++ b/frontend/src/pages/CourseSelector/CourseBanner/CourseBanner.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Typography } from 'antd';
@@ -7,10 +8,16 @@ import CourseSearchBar from 'components/CourseSearchBar';
 import { useAppDispatch } from 'hooks';
 import { addTab } from 'reducers/courseTabsSlice';
 import S from './styles';
+import { CoursesResponse, PlannerResponse } from 'types/userResponse';
 
 const { Title } = Typography;
 
-const CourseBanner = () => {
+type CourseBannerProps = {
+  planner?: PlannerResponse;
+  courses?: CoursesResponse;
+};
+
+const CourseBanner = ({ planner, courses }: CourseBannerProps) => {
   const dispatch = useAppDispatch();
 
   const degreeQuery = useQuery({
@@ -34,7 +41,11 @@ const CourseBanner = () => {
       <Title level={2} className="text">
         {degreeQuery.data?.programCode} - {getUserProgramTitle()}
       </Title>
-      <CourseSearchBar onSelectCallback={(courseCode) => dispatch(addTab(courseCode))} />
+      <CourseSearchBar
+        onSelectCallback={(courseCode) => dispatch(addTab(courseCode))}
+        planner={planner}
+        userCourses={courses}
+      />
     </S.BannerWrapper>
   );
 };

--- a/frontend/src/pages/CourseSelector/CourseBanner/CourseBanner.tsx
+++ b/frontend/src/pages/CourseSelector/CourseBanner/CourseBanner.tsx
@@ -8,16 +8,15 @@ import CourseSearchBar from 'components/CourseSearchBar';
 import { useAppDispatch } from 'hooks';
 import { addTab } from 'reducers/courseTabsSlice';
 import S from './styles';
-import { CoursesResponse, PlannerResponse } from 'types/userResponse';
+import { CoursesResponse } from 'types/userResponse';
 
 const { Title } = Typography;
 
 type CourseBannerProps = {
-  planner?: PlannerResponse;
   courses?: CoursesResponse;
 };
 
-const CourseBanner = ({ planner, courses }: CourseBannerProps) => {
+const CourseBanner = ({ courses }: CourseBannerProps) => {
   const dispatch = useAppDispatch();
 
   const degreeQuery = useQuery({
@@ -43,7 +42,6 @@ const CourseBanner = ({ planner, courses }: CourseBannerProps) => {
       </Title>
       <CourseSearchBar
         onSelectCallback={(courseCode) => dispatch(addTab(courseCode))}
-        planner={planner}
         userCourses={courses}
       />
     </S.BannerWrapper>

--- a/frontend/src/pages/CourseSelector/CourseMenuTitle/CourseMenuTitle.tsx
+++ b/frontend/src/pages/CourseSelector/CourseMenuTitle/CourseMenuTitle.tsx
@@ -18,17 +18,18 @@ type Props = {
 const CourseMenuTitle = ({ courseCode, runMutate, selected, accurate, unlocked, title }: Props) => {
   const isSmall = useMediaQuery('(max-width: 1400px)');
   const theme = useTheme();
+  const locked = !unlocked;
 
   return (
     <S.Wrapper>
       {isSmall ? (
         <Tooltip title={title} placement="topLeft">
-          <S.CourseTitleWrapper selected={selected} locked={!unlocked}>
+          <S.CourseTitleWrapper selected={selected} locked={locked}>
             {courseCode}
           </S.CourseTitleWrapper>
         </Tooltip>
       ) : (
-        <S.CourseTitleWrapper selected={selected} locked={!unlocked}>
+        <S.CourseTitleWrapper selected={selected} locked={locked}>
           {courseCode}: {title}
         </S.CourseTitleWrapper>
       )}

--- a/frontend/src/pages/CourseSelector/CourseSelector.tsx
+++ b/frontend/src/pages/CourseSelector/CourseSelector.tsx
@@ -82,7 +82,7 @@ const CourseSelector = () => {
   return (
     <PageTemplate>
       <S.ContainerWrapper>
-        <CourseBanner planner={plannerQuery.data} courses={coursesQuery.data} />
+        <CourseBanner courses={coursesQuery.data} />
         <CourseTabs />
         <S.ContentWrapper offset={menuOffset}>
           <CourseMenu

--- a/frontend/src/pages/CourseSelector/CourseSelector.tsx
+++ b/frontend/src/pages/CourseSelector/CourseSelector.tsx
@@ -82,7 +82,7 @@ const CourseSelector = () => {
   return (
     <PageTemplate>
       <S.ContainerWrapper>
-        <CourseBanner />
+        <CourseBanner planner={plannerQuery.data} courses={coursesQuery.data} />
         <CourseTabs />
         <S.ContentWrapper offset={menuOffset}>
           <CourseMenu

--- a/frontend/src/pages/GraphicalSelector/GraphicalSelector.tsx
+++ b/frontend/src/pages/GraphicalSelector/GraphicalSelector.tsx
@@ -63,7 +63,11 @@ const GraphicalSelector = () => {
           />
           {!loading && (
             <S.SearchBarWrapper>
-              <CourseSearchBar onSelectCallback={setCourseCode} style={{ width: '25rem' }} />
+              <CourseSearchBar
+                userCourses={coursesQuery.data}
+                onSelectCallback={setCourseCode}
+                style={{ width: '25rem' }}
+              />
             </S.SearchBarWrapper>
           )}
           {fullscreen && (

--- a/frontend/src/test/testUtil.tsx
+++ b/frontend/src/test/testUtil.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, RenderOptions } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import { vi } from 'vitest';

--- a/frontend/src/utils/planner.ts
+++ b/frontend/src/utils/planner.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { CourseMark } from 'types/api';
-import { CoursesResponse, UserResponse } from 'types/userResponse';
+import { UserResponse } from 'types/userResponse';
 import { getToken } from './api/userApi';
 
 export const updateCourseMark = async (courseMark: CourseMark) => {

--- a/frontend/src/utils/planner.ts
+++ b/frontend/src/utils/planner.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { CourseMark } from 'types/api';
-import { UserResponse } from 'types/userResponse';
+import { CoursesResponse, UserResponse } from 'types/userResponse';
 import { getToken } from './api/userApi';
 
 export const updateCourseMark = async (courseMark: CourseMark) => {


### PR DESCRIPTION
Adds a `QuickAddCartButton` to the search bar. This allows for users to add courses to their planner quickly, without needing to load a new course tab, press add to planner and then go back to search. [Image at bottom]

The two uses of the search are the `CourseBar` in `/course-selector` and, `/graphical-selector`.
Currently both have to inject the mutations and `CoursesResponse` state as a dependency.
Consider just calling queries and mutations directly when the react-query mutations are unified.

---

We also perform a few misc. cleanups:
- Prefer `CourseBarSearchProps` over `Props` as a name
- Use `Array<T>` over `T[]`, especially for anonymous record types. This change is for the singular instance relevant to this PR and is not a treesmash.

---

<img width="626" alt="image" src="https://github.com/devsoc-unsw/circles/assets/93496985/44aacd8d-c1f3-47f1-a817-e0ac92534a94">


