### PR TITLE
Add stronger warnings for WAM and exclusion validation

### DIFF
--- a/backend/algorithms/objects/conditions.py
+++ b/backend/algorithms/objects/conditions.py
@@ -261,23 +261,25 @@ class WAMCondition(Condition):
         return False
 
     def validate(self, user: User) -> tuple[bool, list[str]]:
-        """
-        Determines if the user has met the WAM condition for this category.
+        wam, marks_complete = user.wam(self.category)
+        warning = self.get_warning(wam, marks_complete)
 
-        Will always return False and a warning since WAM can fluctuate
-        """
-        warning = self.get_warning(user.wam(self.category))
-        return True, [warning]
+        # If the user has not entered their marks, we allow the course to be unlocked and just display warning as info instead
+        return not marks_complete or warning is None, [warning] if warning is not None else []
 
-    def get_warning(self, applicable_wam: Optional[float]) -> str:
+    def get_warning(self, wam: Optional[float], marks_complete: bool) -> str | None:
         """ Returns an appropriate warning message or None if not needed """
         category = re.sub(r"courses && ([A-Z]{4}) courses", r"\1 courses", str(self.category))
         wam_warning = f"Requires {self.wam} WAM in {category}. "
-        if applicable_wam is None:
+        if not marks_complete:
             return f"{wam_warning} Your WAM in {category} has not been recorded"
-        if applicable_wam >= self.wam:
+
+        # Any string returned here should be a warning (i.e. course is not unlocked)
+        if wam is None:
             return wam_warning
-        return f"{wam_warning} Your WAM in {category} is currently {applicable_wam:.3f}"
+        if wam >= self.wam:
+            return None
+        return f"{wam_warning} Your WAM in {category} is currently {wam:.3f}"
 
     def condition_to_model(self, model: cp_model.CpModel, user: User, courses: list[Tuple[cp_model.IntVar, Course]], course_variable: cp_model.IntVar) -> list[cp_model.Constraint]:
         # straight up true or false if the user's current wam supports the course
@@ -493,7 +495,7 @@ class CourseExclusionCondition(Condition):
 
     def validate(self, user: User) -> tuple[bool, list[str]]:
 
-        is_valid = not user.has_taken_specific_course(self.course)
+        is_valid = not (user.has_taken_specific_course(self.course) or user.is_taking_specific_course(self.course))
         return is_valid, ([] if is_valid else [f"Exclusion: {self.course}"])
 
     def is_path_to(self, course: str) -> bool:

--- a/backend/algorithms/tests/test_user_loading.py
+++ b/backend/algorithms/tests/test_user_loading.py
@@ -21,7 +21,10 @@ def test_user1():
     assert user.in_specialisation("ACCTA2")
     assert user.has_taken_course("COMP1511")
     assert user.has_taken_course("COMP1521")
-    assert isclose(user.wam(), 70.5)
+    
+    wam, marks_complete = user.wam()
+    assert wam is not None and isclose(wam, 70.5)
+    assert marks_complete
     assert user.uoc() == 12
 
 def test_user2():
@@ -32,7 +35,9 @@ def test_user2():
     assert user.has_taken_course("COMP1511")
     assert user.has_taken_course("MATH1131")
     assert user.has_taken_course("MATH1081")
-    assert user.wam() == None
+    wam, marks_complete = user.wam()
+    assert wam == None
+    assert not marks_complete
     assert user.uoc() == 18
 
 
@@ -41,7 +46,9 @@ def test_user3():
 
     assert user.in_program("3778")
     assert user.in_specialisation("COMPA1")
-    assert user.wam() == None
+    wam, marks_complete = user.wam()
+    assert wam == None
+    assert marks_complete
     assert user.uoc() == 0
 
 def test_user_no_data():

--- a/backend/algorithms/tests/test_user_wam_uoc.py
+++ b/backend/algorithms/tests/test_user_wam_uoc.py
@@ -19,11 +19,18 @@ def test_category_instantiation_causes_error():
 def test_course_category_produces_correct_wam():
     user = User(USERS["user4"])
     comp = CourseCategory("COMP")
-    assert user.wam(CourseCategory("FOOD")) is None
-    assert user.wam(comp) == 66
+    wam, marks_complete = user.wam(CourseCategory("FOOD"))
+    assert wam == None
+    assert marks_complete
+
+    wam, marks_complete = user.wam(comp)
+    assert wam == 66
+    assert marks_complete
 
     user.add_courses({"COMP1069": (2, 69)})
-    assert user.wam(comp) == 66.3
+    wam, marks_complete = user.wam(comp)
+    assert wam == 66.3
+    assert marks_complete
 
 
 def test_course_category_produces_correct_uoc():


### PR DESCRIPTION
- Update exclusion condition to check courses in the same/current term
- Update WAM condition to give a warning instead of information message in the event that WAM goal is not met AND all courses in previous terms have associated marks