### PR TITLE
feat/infra/add-env-setup-script

### DIFF
--- a/backend/setup_env.py
+++ b/backend/setup_env.py
@@ -1,0 +1,165 @@
+"""
+Script built on dotenv to set up the required environment variables
+
+Required functionality:
+
+for env variables such as mongo password, where it lives in both backend env and mongodb env, you only need to input it in once
+if the files already exist, when the user is prompted to enter, suggests them to use the old one instead
+this is because we dont want to accidently overwrite the files and be painful to find the auth env vars again
+certain fields allow for empty input, where it will auto generate
+also can specify as keyword command line arguments for easy use in the ci file
+otherwise if no CL argument or existing, will prompt user to enter each
+Main usecases:
+
+in ci, replaces all the echos
+must leave files that are compatible with ci and docker compose env
+python3 setup_env.py --mongodb-pass="ollipass
+"""
+
+from os import write
+from pathlib import Path
+from typing import Literal, Optional
+
+import dotenv
+
+# Assumes this file is in `/backend/setup_env.py`
+PROJECT_ROOT: Path = Path(__file__).parent.parent
+ENV_DIR: Path = PROJECT_ROOT.joinpath('env')
+
+BACKEND_ENV: Path = ENV_DIR.joinpath("backend.env")
+FRONTEND_ENV: Path = ENV_DIR.joinpath("frontend.env")
+MONGO_ENV: Path = ENV_DIR.joinpath('mongodb.env')
+SESSIONSDB_ENV: Path = ENV_DIR.joinpath('sessionsdb.env')
+
+"""
+- name of the variable
+- files to insert it in
+- file to read it from
+- default value (if any)
+"""
+
+"""
+Creating Environment Variables
+MongoDB and the backend require a few environment variables to get started. In the root folder, create a folder called env and add three files: backend.env, mongodb.env and frontend.env.
+
+In backend.env, add the environment variables:
+
+MONGODB_USERNAME=name
+MONGODB_PASSWORD=name
+MONGODB_SERVICE_HOSTNAME=mongodb
+FOR PRODUCTION, also add:
+
+FORWARDED_ALLOW_IPS=*
+In mongodb.env, add:
+
+MONGO_INITDB_ROOT_USERNAME=name
+MONGO_INITDB_ROOT_PASSWORD=name
+In frontend.env, add:
+
+VITE_BACKEND_API_BASE_URL=http://localhost:8000/
+NOTE: The VITE_BACKEND_API_BASE_URL environment variable is the base url endpoint that the backend is running on. If the environment variable is not specified, the react application will default to using http://localhost:8000/ as the base url when calling the API endpoint.
+
+You can use any random username and password. The username and password in backend.env must match the values in mongodb.env. The env folder has been added to .giti
+"""
+
+def prompt_variable(name: str, default_value: Optional[str] = None) -> str:
+    if default_value is not None:
+        print(f"Enter value for {name} (press [enter] to accept default '{default_value}')")
+        entered_value = input().strip()
+        return entered_value or default_value
+    else:
+        print(f"Enter value for {name}")
+        return input().strip()
+
+def in_production() -> bool:
+    # TODO: get from the args
+
+    return False
+
+def write_env_file(env: dict[str, str], file: Path):
+    print(f"Attempting to write env to {file}")
+    content = "\n".join(
+        f"{key}={value}\n"
+        for key, value in env.items()
+    )
+    with open(file, mode='w') as f:
+        f.write(content)
+
+    print(f"Succesfully wrote {len(env)} items to {file}")
+    
+
+def main() -> None:
+    # TODO: also accept CLI arguments
+    if not ENV_DIR.exists():
+        ENV_DIR.mkdir()
+    prexisting_env = dotenv.dotenv_values(BACKEND_ENV)
+    prexisting_env.update(dotenv.dotenv_values(FRONTEND_ENV))
+
+    backend_env: dict[str, str] = {}
+    frontend_env: dict[str, str] = {}
+    mongo_env: dict[str, str] = {}
+    sessionsdb_env: dict[str, str] = {}
+
+    # sessionsdb - backend
+    sessionsdb_username = prompt_variable('SESSIONSDB_USERNAME', prexisting_env.get("SESSIONSDB_USERNAME", "name"))
+    sessionsdb_pass = prompt_variable('SESSIONSDB_PASSWORD', prexisting_env.get("SESSIONSDB_PASSWORD", "pass123"))
+    sessionsdb_hostname = prompt_variable("SESSIONSDB_SERVICE_HOSTNAME", prexisting_env.get("SESSIONSDB_SERVICE_HOSTNAME", "sessiondb"))
+
+    # cse auth - backend
+    auth_cse_client_id = prompt_variable("AUTH_CSE_CLIENT_ID", prexisting_env.get("AUTH_CSE_CLIENT_ID", "..."))
+    auth_cse_client_secret = prompt_variable("AUTH_CSE_CLIENT_SECRET", prexisting_env.get("AUTH_CSE_CLIENT_SECRET", "..."))
+    auth_cse_redirect_base_uri = prompt_variable("AUTH_REDIRECT_BASE_URI", prexisting_env.get("AUTH_REDIRECT_BASE_URI", "http://localhost:3000"))
+
+    backend_env["AUTH_CSE_CLIENT_ID"] = auth_cse_client_id
+    backend_env["AUTH_CSE_CLIENT_SECRET"] = auth_cse_client_secret
+    backend_env["AUTH_REDIRECT_BASE_URI"] = auth_cse_redirect_base_uri
+
+    backend_env["SESSIONSDB_USERNAME"] = sessionsdb_username
+    backend_env["SESSIONSDB_PASSWORD"] = sessionsdb_pass
+    backend_env["SESSIONSDB_SERVICE_HOSTNAME"] = sessionsdb_hostname
+
+    # redis - sessionsdb
+    base_redis_args = f"--user {sessionsdb_username} on allcommands allkeys allchannels >{sessionsdb_pass}"
+    additional_redis_args = prompt_variable("ADDITIONAL_REDIS_ARGS", prexisting_env.get("ADDITIONAL_REDIS_ARGS", ""))
+    redis_args = f"{base_redis_args} {additional_redis_args}" if additional_redis_args else base_redis_args
+    sessionsdb_env["REDIS_ARGS"] = redis_args
+
+
+    # Misc - backend
+    python_version = prompt_variable("PYTHON_VERSION", prexisting_env.get("PYTHON_VERSION", "python3"))
+    backend_env["PYTHON_VERSION"] = python_version
+
+    if in_production():
+        backend_env["FORWARDED_ALLOWED_IPS"] = "*"
+
+    # mongodb - backend + mongodb
+    mongo_username = prompt_variable('MONGODB_USERNAME', prexisting_env.get("MONGODB_USERNAME", "name"))
+    mongo_pass = prompt_variable('MONGODB_PASSWORD', prexisting_env.get("MONGODB_PASSWORD", "pass123"))
+    mongo_hostname = prompt_variable("MONGODB_SERVICE_HOSTNAME", prexisting_env.get("MONGODB_SERVICE_HOSTNAME", "mongodb"))
+
+    backend_env["MONGODB_USERNAME"] = mongo_username
+    backend_env["MONGODB_PASSWORD"] = mongo_pass
+    backend_env["MONGODB_SERVICE_HOSTNAME"] = mongo_hostname
+
+    mongo_env["MONGO_INITDB_ROOT_USERNAME"] = mongo_username
+    mongo_env["MONGO_INITDB_ROOT_PASSWORD"] = mongo_pass
+
+
+
+    # frontend
+    vite_backend_base_url = prompt_variable("VITE_BACKEND_API_BASE_URL", prexisting_env.get("VITE_BACKEND_API_BASE_URL", "http://localhost:8000/"))
+    vite_env = prompt_variable("VITE_ENV", prexisting_env.get("VITE_ENV", "dev"))
+    
+    frontend_env["VITE_BACKEND_API_BASE_URL"] = vite_backend_base_url
+    frontend_env["VITE_ENV"] = vite_env
+
+    # Finished reading - save all changes
+    write_env_file(backend_env, BACKEND_ENV)
+    write_env_file(frontend_env, FRONTEND_ENV)
+    write_env_file(mongo_env, MONGO_ENV)
+    write_env_file(sessionsdb_env, SESSIONSDB_ENV)
+    print("Done. Exiting Successfully")
+
+if __name__ == "__main__":
+    main()
+    pass

--- a/backend/setup_env.py
+++ b/backend/setup_env.py
@@ -118,13 +118,19 @@ class EnvReader():
             print(f"Successfully read value from args. Using {name}={value_from_cli}")
             return value_from_cli
 
+        def read_input():
+            try:
+                return input().strip()
+            except EOFError:
+                return ""
+
         if (default_value := self.preexisting_env.get(name)) is not None:
             print(f"Enter value for {name} (press [enter] to accept default '{default_value}')")
-            entered_value = input().strip()
+            entered_value = read_input()
             return entered_value or default_value
         else:
             print(f"Enter value for {name}")
-            return input().strip()
+            return read_input()
 
 def parse_cli_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Set up env/ folder and required env files")

--- a/backend/setup_env.py
+++ b/backend/setup_env.py
@@ -33,7 +33,7 @@ def main() -> None:
     # sessionsdb - backend
     sessionsdb_username = env.get_variable('SESSIONSDB_USERNAME', "name")
     sessionsdb_pass = env.get_variable('SESSIONSDB_PASSWORD', "pass123")
-    sessionsdb_hostname = env.get_variable("SESSIONSDB_SERVICE_HOSTNAME", "sessiondb")
+    sessionsdb_hostname = env.get_variable("SESSIONSDB_SERVICE_HOSTNAME", "sessionsdb")
 
     # cse auth - backend
     auth_cse_client_id = env.get_variable("AUTH_CSE_CLIENT_ID", "...")

--- a/backend/setup_env.py
+++ b/backend/setup_env.py
@@ -168,7 +168,7 @@ def write_env_file(env: dict[str, str], file: Path):
     with open(file, mode='w') as f:
         f.write(content)
 
-    print(f"Succesfully wrote {len(env)} items to {file}")
+    print(f"Successfully wrote {len(env)} items to {file}")
 if __name__ == "__main__":
     main()
     pass

--- a/backend/setup_env.py
+++ b/backend/setup_env.py
@@ -171,4 +171,3 @@ def write_env_file(env: dict[str, str], file: Path):
     print(f"Successfully wrote {len(env)} items to {file}")
 if __name__ == "__main__":
     main()
-    pass

--- a/backend/setup_env.py
+++ b/backend/setup_env.py
@@ -1,19 +1,5 @@
 """
 Script built on dotenv to set up the required environment variables
-
-Required functionality:
-
-for env variables such as mongo password, where it lives in both backend env and mongodb env, you only need to input it in once
-if the files already exist, when the user is prompted to enter, suggests them to use the old one instead
-this is because we dont want to accidently overwrite the files and be painful to find the auth env vars again
-certain fields allow for empty input, where it will auto generate
-also can specify as keyword command line arguments for easy use in the ci file
-otherwise if no CL argument or existing, will prompt user to enter each
-Main usecases:
-
-in ci, replaces all the echos
-must leave files that are compatible with ci and docker compose env
-python3 setup_env.py --mongodb-pass="ollipass
 """
 
 from os import write
@@ -30,62 +16,6 @@ BACKEND_ENV: Path = ENV_DIR.joinpath("backend.env")
 FRONTEND_ENV: Path = ENV_DIR.joinpath("frontend.env")
 MONGO_ENV: Path = ENV_DIR.joinpath('mongodb.env')
 SESSIONSDB_ENV: Path = ENV_DIR.joinpath('sessionsdb.env')
-
-"""
-- name of the variable
-- files to insert it in
-- file to read it from
-- default value (if any)
-"""
-
-"""
-Creating Environment Variables
-MongoDB and the backend require a few environment variables to get started. In the root folder, create a folder called env and add three files: backend.env, mongodb.env and frontend.env.
-
-In backend.env, add the environment variables:
-
-MONGODB_USERNAME=name
-MONGODB_PASSWORD=name
-MONGODB_SERVICE_HOSTNAME=mongodb
-FOR PRODUCTION, also add:
-
-FORWARDED_ALLOW_IPS=*
-In mongodb.env, add:
-
-MONGO_INITDB_ROOT_USERNAME=name
-MONGO_INITDB_ROOT_PASSWORD=name
-In frontend.env, add:
-
-VITE_BACKEND_API_BASE_URL=http://localhost:8000/
-NOTE: The VITE_BACKEND_API_BASE_URL environment variable is the base url endpoint that the backend is running on. If the environment variable is not specified, the react application will default to using http://localhost:8000/ as the base url when calling the API endpoint.
-
-You can use any random username and password. The username and password in backend.env must match the values in mongodb.env. The env folder has been added to .giti
-"""
-
-def prompt_variable(name: str, default_value: Optional[str] = None) -> str:
-    if default_value is not None:
-        print(f"Enter value for {name} (press [enter] to accept default '{default_value}')")
-        entered_value = input().strip()
-        return entered_value or default_value
-    else:
-        print(f"Enter value for {name}")
-        return input().strip()
-
-def in_production() -> bool:
-    # TODO: get from the args
-
-    return False
-
-def write_env_file(env: dict[str, str], file: Path):
-    print(f"Attempting to write env to {file}")
-    content = "\n".join(
-        f"{key}={value}\n"
-        for key, value in env.items()
-    )
-    with open(file, mode='w') as f:
-        f.write(content)
-
-    print(f"Succesfully wrote {len(env)} items to {file}")
     
 
 def main() -> None:
@@ -160,6 +90,30 @@ def main() -> None:
     write_env_file(sessionsdb_env, SESSIONSDB_ENV)
     print("Done. Exiting Successfully")
 
+def prompt_variable(name: str, default_value: Optional[str] = None) -> str:
+    if default_value is not None:
+        print(f"Enter value for {name} (press [enter] to accept default '{default_value}')")
+        entered_value = input().strip()
+        return entered_value or default_value
+    else:
+        print(f"Enter value for {name}")
+        return input().strip()
+
+def in_production() -> bool:
+    # TODO: get from the args
+
+    return False
+
+def write_env_file(env: dict[str, str], file: Path):
+    print(f"Attempting to write env to {file}")
+    content = "\n".join(
+        f"{key}={value}\n"
+        for key, value in env.items()
+    )
+    with open(file, mode='w') as f:
+        f.write(content)
+
+    print(f"Succesfully wrote {len(env)} items to {file}")
 if __name__ == "__main__":
     main()
     pass

--- a/backend/setup_env.py
+++ b/backend/setup_env.py
@@ -4,9 +4,11 @@ Script built on dotenv to set up the required environment variables
 
 from os import write
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
+from click import Option
 import dotenv
+import argparse
 
 # Assumes this file is in `/backend/setup_env.py`
 PROJECT_ROOT: Path = Path(__file__).parent.parent
@@ -22,8 +24,8 @@ def main() -> None:
     # TODO: also accept CLI arguments
     if not ENV_DIR.exists():
         ENV_DIR.mkdir()
-    prexisting_env = dotenv.dotenv_values(BACKEND_ENV)
-    prexisting_env.update(dotenv.dotenv_values(FRONTEND_ENV))
+
+    env = EnvReader(env_files=[BACKEND_ENV, FRONTEND_ENV, SESSIONSDB_ENV])
 
     backend_env: dict[str, str] = {}
     frontend_env: dict[str, str] = {}
@@ -31,14 +33,14 @@ def main() -> None:
     sessionsdb_env: dict[str, str] = {}
 
     # sessionsdb - backend
-    sessionsdb_username = prompt_variable('SESSIONSDB_USERNAME', prexisting_env.get("SESSIONSDB_USERNAME", "name"))
-    sessionsdb_pass = prompt_variable('SESSIONSDB_PASSWORD', prexisting_env.get("SESSIONSDB_PASSWORD", "pass123"))
-    sessionsdb_hostname = prompt_variable("SESSIONSDB_SERVICE_HOSTNAME", prexisting_env.get("SESSIONSDB_SERVICE_HOSTNAME", "sessiondb"))
+    sessionsdb_username = env.get_variable('SESSIONSDB_USERNAME', "name")
+    sessionsdb_pass = env.get_variable('SESSIONSDB_PASSWORD', "pass123")
+    sessionsdb_hostname = env.get_variable("SESSIONSDB_SERVICE_HOSTNAME", "sessiondb")
 
     # cse auth - backend
-    auth_cse_client_id = prompt_variable("AUTH_CSE_CLIENT_ID", prexisting_env.get("AUTH_CSE_CLIENT_ID", "..."))
-    auth_cse_client_secret = prompt_variable("AUTH_CSE_CLIENT_SECRET", prexisting_env.get("AUTH_CSE_CLIENT_SECRET", "..."))
-    auth_cse_redirect_base_uri = prompt_variable("AUTH_REDIRECT_BASE_URI", prexisting_env.get("AUTH_REDIRECT_BASE_URI", "http://localhost:3000"))
+    auth_cse_client_id = env.get_variable("AUTH_CSE_CLIENT_ID", "...")
+    auth_cse_client_secret = env.get_variable("AUTH_CSE_CLIENT_SECRET", "...")
+    auth_cse_redirect_base_uri = env.get_variable("AUTH_REDIRECT_BASE_URI", "http://localhost:3000")
 
     backend_env["AUTH_CSE_CLIENT_ID"] = auth_cse_client_id
     backend_env["AUTH_CSE_CLIENT_SECRET"] = auth_cse_client_secret
@@ -50,22 +52,23 @@ def main() -> None:
 
     # redis - sessionsdb
     base_redis_args = f"--user {sessionsdb_username} on allcommands allkeys allchannels >{sessionsdb_pass}"
-    additional_redis_args = prompt_variable("ADDITIONAL_REDIS_ARGS", prexisting_env.get("ADDITIONAL_REDIS_ARGS", ""))
+    additional_redis_args = env.get_variable("ADDITIONAL_REDIS_ARGS", "")
     redis_args = f"{base_redis_args} {additional_redis_args}" if additional_redis_args else base_redis_args
+    sessionsdb_env["ADDITIONAL_REDIS_ARGS"] = additional_redis_args
     sessionsdb_env["REDIS_ARGS"] = redis_args
 
 
     # Misc - backend
-    python_version = prompt_variable("PYTHON_VERSION", prexisting_env.get("PYTHON_VERSION", "python3"))
+    python_version = env.get_variable("PYTHON_VERSION", "python3")
     backend_env["PYTHON_VERSION"] = python_version
 
     if in_production():
         backend_env["FORWARDED_ALLOWED_IPS"] = "*"
 
     # mongodb - backend + mongodb
-    mongo_username = prompt_variable('MONGODB_USERNAME', prexisting_env.get("MONGODB_USERNAME", "name"))
-    mongo_pass = prompt_variable('MONGODB_PASSWORD', prexisting_env.get("MONGODB_PASSWORD", "pass123"))
-    mongo_hostname = prompt_variable("MONGODB_SERVICE_HOSTNAME", prexisting_env.get("MONGODB_SERVICE_HOSTNAME", "mongodb"))
+    mongo_username = env.get_variable('MONGODB_USERNAME', "name")
+    mongo_pass = env.get_variable('MONGODB_PASSWORD', "pass123")
+    mongo_hostname = env.get_variable("MONGODB_SERVICE_HOSTNAME", "mongodb")
 
     backend_env["MONGODB_USERNAME"] = mongo_username
     backend_env["MONGODB_PASSWORD"] = mongo_pass
@@ -77,8 +80,8 @@ def main() -> None:
 
 
     # frontend
-    vite_backend_base_url = prompt_variable("VITE_BACKEND_API_BASE_URL", prexisting_env.get("VITE_BACKEND_API_BASE_URL", "http://localhost:8000/"))
-    vite_env = prompt_variable("VITE_ENV", prexisting_env.get("VITE_ENV", "dev"))
+    vite_backend_base_url = env.get_variable("VITE_BACKEND_API_BASE_URL", "http://localhost:8000/")
+    vite_env = env.get_variable("VITE_ENV", "dev")
     
     frontend_env["VITE_BACKEND_API_BASE_URL"] = vite_backend_base_url
     frontend_env["VITE_ENV"] = vite_env
@@ -88,7 +91,61 @@ def main() -> None:
     write_env_file(frontend_env, FRONTEND_ENV)
     write_env_file(mongo_env, MONGO_ENV)
     write_env_file(sessionsdb_env, SESSIONSDB_ENV)
-    print("Done. Exiting Successfully")
+    print("Finished writing all env files. Exiting successfully")
+
+class EnvReader():
+
+    def __init__(self, *, env_files: list[Path]) -> None:
+        cli_args = parse_cli_args()
+
+        self.cli_args: dict[str, str] = {
+            k: str(v) for k, v in vars(cli_args).items() if v is not None
+        }
+        self.in_production = self.cli_args.get("production") == str(True)
+
+        print("in prod", self.in_production)
+        self.preexisting_env: dict[str, str] = {}
+
+        for env_file in env_files:
+            parsed_env = {
+                key: value
+                for key, value in dotenv.dotenv_values(env_file).items()
+                if value is not None
+            }
+            self.preexisting_env.update(parsed_env)
+
+    def get_variable(self, name: str, default: Optional[str] = None) -> str:
+        # CLI arguments have highest priority. If provided, dont ask for value
+        if (value_from_cli := self.cli_args.get(name.lower())) is not None:
+            print(f"Successfully read value from args. Using {name}={value_from_cli}")
+            return value_from_cli
+
+        if (default_value := self.preexisting_env.get(name)) is not None:
+            print(f"Enter value for {name} (press [enter] to accept default '{default_value}')")
+            entered_value = input().strip()
+            return entered_value or default_value
+        else:
+            print(f"Enter value for {name}")
+            return input().strip()
+
+
+def parse_cli_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Set up env/ folder and required env files")
+    parser.add_argument("--sessionsdb_username", type=str)
+    parser.add_argument("--sessionsdb_password", type=str)
+    parser.add_argument("--sessionsdb_service_hostname", type=str)
+
+    parser.add_argument("--auth_cse_client_id", type=str)
+    parser.add_argument("--auth_cse_client_secret", type=str)
+    parser.add_argument("--auth_redirect_base_uri", type=str)
+
+    
+    parser.add_argument("--additional_redis_args", type=str)
+    parser.add_argument("--python_version", type=str)
+    parser.add_argument("--prod", "--production", action="store_true")
+
+    return parser.parse_args()
+
 
 def prompt_variable(name: str, default_value: Optional[str] = None) -> str:
     if default_value is not None:

--- a/setup_env.py
+++ b/setup_env.py
@@ -3,14 +3,14 @@ Script built on dotenv to set up the required environment variables
 """
 
 import argparse
-from os import write
 import os
 from pathlib import Path
 from typing import Any, Optional
 
 import dotenv
 
-# Assumes this file is in `/`
+# Assuming the file is in `/`, allows this to be run from anywhere and
+# not worry about relative paths / the user's CWD
 PROJECT_ROOT: Path = Path(__file__).parent
 ENV_DIR: Path = PROJECT_ROOT.joinpath('env')
 
@@ -19,8 +19,8 @@ FRONTEND_ENV: Path = ENV_DIR.joinpath("frontend.env")
 MONGO_ENV: Path = ENV_DIR.joinpath('mongodb.env')
 SESSIONSDB_ENV: Path = ENV_DIR.joinpath('sessionsdb.env')
 
-def main() -> None:
 
+def main() -> None:
     cli_args = vars(parse_cli_args())
     if bool(cli_args.get("clean")):
         for file in ENV_DIR.iterdir():
@@ -185,5 +185,6 @@ def write_env_file(env: dict[str, Optional[str]], file: Path):
         f.write(content)
 
     print(f"Successfully wrote {len(env)} items to {file}")
+
 if __name__ == "__main__":
     main()

--- a/setup_env.py
+++ b/setup_env.py
@@ -30,7 +30,7 @@ def main() -> None:
     if not ENV_DIR.exists():
         ENV_DIR.mkdir()
 
-    env = EnvReader(env_files=[BACKEND_ENV, FRONTEND_ENV, SESSIONSDB_ENV], cli_args=cli_args)
+    env = EnvReader(env_files=[BACKEND_ENV, FRONTEND_ENV, SESSIONSDB_ENV, MONGO_ENV], cli_args=cli_args)
 
     backend_env: dict[str, Optional[str]] = {}
     frontend_env: dict[str, Optional[str]] = {}
@@ -153,6 +153,8 @@ def parse_cli_args() -> argparse.Namespace:
     parser.add_argument("--python_version", type=str)
     parser.add_argument("--prod", "--production", action="store_true")
 
+    parser.add_argument("--mongodb_service_hostname", type=str)
+
     parser.add_argument(
         "--default",
         action="store_true",
@@ -163,6 +165,7 @@ def parse_cli_args() -> argparse.Namespace:
         action="store_true",
         help="Force remove the pre-existing env folder if it exists. Do not use old env values as a fallback"
     )
+
 
     return parser.parse_args()
 

--- a/setup_env.py
+++ b/setup_env.py
@@ -9,8 +9,8 @@ from typing import Optional
 
 import dotenv
 
-# Assumes this file is in `/backend/setup_env.py`
-PROJECT_ROOT: Path = Path(__file__).parent.parent
+# Assumes this file is in `/`
+PROJECT_ROOT: Path = Path(__file__).parent
 ENV_DIR: Path = PROJECT_ROOT.joinpath('env')
 
 BACKEND_ENV: Path = ENV_DIR.joinpath("backend.env")

--- a/setup_env.py
+++ b/setup_env.py
@@ -17,7 +17,6 @@ BACKEND_ENV: Path = ENV_DIR.joinpath("backend.env")
 FRONTEND_ENV: Path = ENV_DIR.joinpath("frontend.env")
 MONGO_ENV: Path = ENV_DIR.joinpath('mongodb.env')
 SESSIONSDB_ENV: Path = ENV_DIR.joinpath('sessionsdb.env')
-    
 
 def main() -> None:
     if not ENV_DIR.exists():
@@ -96,6 +95,7 @@ class EnvReader():
         cli_args = vars(parse_cli_args())
 
         self.in_production = bool(cli_args.get("prod"))
+        self.default_mode = bool(cli_args.get("default"))
         self.cli_args: dict[str, str] = {
             k: str(v) for k, v in cli_args.items() if v is not None
         }
@@ -117,6 +117,8 @@ class EnvReader():
             return value_from_cli
 
         def read_input() -> Optional[str]:
+            if self.default_mode:
+                return None
             try:
                 entered_line = input().strip()
                 return None if not entered_line else entered_line
@@ -145,6 +147,12 @@ def parse_cli_args() -> argparse.Namespace:
     parser.add_argument("--additional_redis_args", type=str)
     parser.add_argument("--python_version", type=str)
     parser.add_argument("--prod", "--production", action="store_true")
+
+    parser.add_argument(
+        "--default",
+        action="store_true",
+        help="Don't read from stdin and use only the default values"
+    )
 
     return parser.parse_args()
 

--- a/setup_env.py
+++ b/setup_env.py
@@ -83,7 +83,6 @@ def main() -> None:
     mongo_env["MONGO_INITDB_ROOT_PASSWORD"] = mongo_pass
 
 
-
     # frontend
     vite_backend_base_url = env.get_variable("VITE_BACKEND_API_BASE_URL", "http://localhost:8000/")
     vite_env = env.get_variable("VITE_ENV", "dev")

--- a/setup_env.py
+++ b/setup_env.py
@@ -153,8 +153,8 @@ def parse_cli_args() -> argparse.Namespace:
     parser.add_argument("--python_version", type=str)
     parser.add_argument("--prod", "--production", action="store_true")
 
-    parser.add_argument("--MONGODB_USERNAME", type=str)
-    parser.add_argument("--MONGODB_PASSWORD", type=str)
+    parser.add_argument("--mongodb_username", type=str)
+    parser.add_argument("--mongodb_password", type=str)
     parser.add_argument("--mongodb_service_hostname", type=str)
 
     parser.add_argument(

--- a/setup_env.py
+++ b/setup_env.py
@@ -92,10 +92,10 @@ def main() -> None:
     frontend_env["VITE_ENV"] = vite_env
 
     # Finished reading - save all changes
-    write_env_file(backend_env, BACKEND_ENV, require_complete=True)
-    write_env_file(frontend_env, FRONTEND_ENV, require_complete=False)
-    write_env_file(mongo_env, MONGO_ENV, require_complete=False)
-    write_env_file(sessionsdb_env, SESSIONSDB_ENV, require_complete=True)
+    write_env_file(backend_env, BACKEND_ENV)
+    write_env_file(frontend_env, FRONTEND_ENV)
+    write_env_file(mongo_env, MONGO_ENV)
+    write_env_file(sessionsdb_env, SESSIONSDB_ENV)
     print("Finished writing all env files. Exiting successfully")
 
 class EnvReader():
@@ -168,25 +168,13 @@ def parse_cli_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def write_env_file(env: dict[str, Optional[str]], file: Path, *, require_complete: bool):
+def write_env_file(env: dict[str, Optional[str]], file: Path):
     """
     Tries to write `env` to `file` in the `.env` format.
     Skips any `None` valued elements.
-
-    If `required_complete` is `True`, then we only write if ALL values
-    are present.
     """
-    print(f"Attempting to write env to {file}")
 
-    if require_complete:
-        missing_values = [k for k, v in env.items() if v is None]
-        if missing_values and missing_values == len(env):
-            print(f"No values given. Skipping write of {file}")
-            return
-        if missing_values and missing_values != len(env):
-            print(f"ERROR writing env to {file}. Require all or no keys to be populated.")
-            print(f"The following {len(missing_values)} keys were required but not provided: {missing_values}")
-            return
+    print(f"Attempting to write env to {file}")
 
     content = "\n".join(
         f"{key}={value}\n"

--- a/setup_env.py
+++ b/setup_env.py
@@ -92,7 +92,6 @@ def main() -> None:
     print("Finished writing all env files. Exiting successfully")
 
 class EnvReader():
-
     def __init__(self, *, env_files: list[Path]) -> None:
         cli_args = vars(parse_cli_args())
 
@@ -101,7 +100,6 @@ class EnvReader():
             k: str(v) for k, v in cli_args.items() if v is not None
         }
 
-        print("in prod", self.in_production)
         self.preexisting_env: dict[str, str] = {}
 
         for env_file in env_files:
@@ -124,7 +122,7 @@ class EnvReader():
             except EOFError:
                 return ""
 
-        if (default_value := self.preexisting_env.get(name)) is not None:
+        if (default_value := self.preexisting_env.get(name, default)) is not None:
             print(f"Enter value for {name} (press [enter] to accept default '{default_value}')")
             entered_value = read_input()
             return entered_value or default_value
@@ -149,15 +147,6 @@ def parse_cli_args() -> argparse.Namespace:
 
     return parser.parse_args()
 
-
-def prompt_variable(name: str, default_value: Optional[str] = None) -> str:
-    if default_value is not None:
-        print(f"Enter value for {name} (press [enter] to accept default '{default_value}')")
-        entered_value = input().strip()
-        return entered_value or default_value
-    else:
-        print(f"Enter value for {name}")
-        return input().strip()
 
 def write_env_file(env: dict[str, str], file: Path):
     print(f"Attempting to write env to {file}")

--- a/setup_env.py
+++ b/setup_env.py
@@ -71,8 +71,8 @@ def main() -> None:
         backend_env["FORWARDED_ALLOWED_IPS"] = "*"
 
     # mongodb - backend + mongodb
-    mongo_username = env.get_variable('MONGODB_USERNAME', "name")
-    mongo_pass = env.get_variable('MONGODB_PASSWORD', "pass123")
+    mongo_username = env.get_variable("MONGODB_USERNAME", "name")
+    mongo_pass = env.get_variable("MONGODB_PASSWORD", "pass123")
     mongo_hostname = env.get_variable("MONGODB_SERVICE_HOSTNAME", "mongodb")
 
     backend_env["MONGODB_USERNAME"] = mongo_username
@@ -153,6 +153,8 @@ def parse_cli_args() -> argparse.Namespace:
     parser.add_argument("--python_version", type=str)
     parser.add_argument("--prod", "--production", action="store_true")
 
+    parser.add_argument("--MONGODB_USERNAME", type=str)
+    parser.add_argument("--MONGODB_PASSWORD", type=str)
     parser.add_argument("--mongodb_service_hostname", type=str)
 
     parser.add_argument(


### PR DESCRIPTION
Solves #1157 

---

Sets up all the env variables that are needed.
Supports taking in arguments from the commmand line.

Command line arguments are given top priority. If one is provided, the user will not be prompted to enter a value for env variable.
If the variable is not specified from the command line, the user will be prompted to specify one, or press `[enter]` to accept the specified default value.

The default value is either taken from the pre-existing env files (higher priority) or, a sane default if the env files do not already exist.

This means that the user can run `python3 backend/setup_env.py` and spam enter to accept all defaults, or echo in no input to accept all defaults.