### PR TITLE
feat: Add support for user data migration from local storage

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@rive-app/react-canvas": "4.8.3",
         "@tanstack/react-query": "5.29.2",
         "@tippyjs/react": "4.2.6",
-        "antd": "5.20.2",
+        "antd": "5.21.4",
         "axios": "1.7.7",
         "dayjs": "1.11.11",
         "fast-fuzzy": "1.12.0",
@@ -120,9 +120,10 @@
       }
     },
     "node_modules/@ant-design/cssinjs": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.21.0.tgz",
-      "integrity": "sha512-gIilraPl+9EoKdYxnupxjHB/Q6IHNRjEXszKbDxZdsgv4sAZ9pjkCq8yanDWNvyfjp4leir2OVAJm0vxwKK8YA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.21.1.tgz",
+      "integrity": "sha512-tyWnlK+XH7Bumd0byfbCiZNK43HEubMoCcu9VxwsAwiHdHTgWa+tMN0/yvxa+e8EzuFP1WdUNNPclRpVtD33lg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
@@ -130,7 +131,7 @@
         "classnames": "^2.3.1",
         "csstype": "^3.1.3",
         "rc-util": "^5.35.0",
-        "stylis": "^4.0.13"
+        "stylis": "^4.3.3"
       },
       "peerDependencies": {
         "react": ">=16.0.0",
@@ -138,9 +139,9 @@
       }
     },
     "node_modules/@ant-design/cssinjs-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.0.3.tgz",
-      "integrity": "sha512-BrztZZKuoYcJK8uEH40ylBemf/Mu/QPiDos56g2bv6eUoniQkgQHOCOvA3+pncoFO1TaS8xcUCIqGzDA0I+ZVQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.1.tgz",
+      "integrity": "sha512-2HAiyGGGnM0es40SxdszeQAU5iWp41wBIInq+ONTCKjlSKOrzQfnw4JDtB8IBmqE6tQaEKwmzTP2LGdt5DSwYQ==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/cssinjs": "^1.21.0",
@@ -151,6 +152,12 @@
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
+    },
+    "node_modules/@ant-design/cssinjs/node_modules/stylis": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.4.tgz",
+      "integrity": "sha512-osIBl6BGUmSfDkyH2mB7EFvCJntXDrLhKjHTRj/rK6xLH0yuPrHULDRQzKokSOD4VoorhtKpfcfW1GAntu8now==",
+      "license": "MIT"
     },
     "node_modules/@ant-design/fast-color": {
       "version": "2.0.6",
@@ -651,9 +658,10 @@
       }
     },
     "node_modules/@antv/g2": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-5.2.0.tgz",
-      "integrity": "sha512-wruxga0RdaCtUi2LcJ5qgrBTP37tUwCYbBJYc3R8dW7oywB5ZqUmPWI7qh6lUh2hIS+hGsNsWvVa7vQOQSIeSw==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-5.2.7.tgz",
+      "integrity": "sha512-bOU7ZJfa735KCqIsWWwlFtn3pc8TwJIckBhy7X8PFcxTuMIXzgqOt7vbMMdF4psBHMyIIOCDAo8zf9rGhgjEzA==",
+      "license": "MIT",
       "dependencies": {
         "@antv/component": "^2.0.0",
         "@antv/coord": "^0.4.6",
@@ -661,7 +669,6 @@
         "@antv/g": "^6.0.0",
         "@antv/g-canvas": "^2.0.0",
         "@antv/g-plugin-dragndrop": "^2.0.0",
-        "@antv/path-util": "^3.0.1",
         "@antv/scale": "^0.4.12",
         "@antv/util": "^3.3.5",
         "d3-array": "^3.2.4",
@@ -673,7 +680,6 @@
         "d3-path": "^3.1.0",
         "d3-scale-chromatic": "^3.0.0",
         "d3-shape": "^3.2.0",
-        "d3-voronoi": "^1.1.4",
         "flru": "^1.0.2",
         "fmin": "^0.0.2",
         "pdfast": "^0.2.0"
@@ -1014,16 +1020,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@antv/path-util": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@antv/path-util/-/path-util-3.0.1.tgz",
-      "integrity": "sha512-tpvAzMpF9Qm6ik2YSMqICNU5tco5POOW7S4XoxZAI/B0L26adU+Md/SmO0BBo2SpuywKvzPH3hPT3xmoyhr04Q==",
-      "dependencies": {
-        "gl-matrix": "^3.1.0",
-        "lodash-es": "^4.17.21",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/@antv/scale": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/@antv/scale/-/scale-0.4.16.tgz",
@@ -1337,9 +1333,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
+      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -1408,7 +1404,8 @@
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
@@ -1426,7 +1423,8 @@
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -2297,6 +2295,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.4.0.tgz",
       "integrity": "sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "rc-util": "^5.27.0"
@@ -2371,9 +2370,10 @@
       }
     },
     "node_modules/@rc-component/tour": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.0.tgz",
-      "integrity": "sha512-h6hyILDwL+In9GAgRobwRWihLqqsD7Uft3fZGrJ7L4EiyCoxbnNYwzPXDfz7vNDhWeVyvAWQJj9fJCzpI4+b4g==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.1.tgz",
+      "integrity": "sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "@rc-component/portal": "^1.0.0-9",
@@ -2390,9 +2390,9 @@
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.1.tgz",
-      "integrity": "sha512-fuU11J8pOt6+U/tU6/CAv8wjCwGaNeRk9f5k8HQth7JBbJ6MMH62WhGycVW75VnXfBZgL/7kO+wbiO2Xc9U9sQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.2.3.tgz",
+      "integrity": "sha512-X1oFIpKoXAMXNDYCviOmTfuNuYxE4h5laBsyCqVAVMjNHxoF3/uiyA7XdegK1XbCvBbCZ6P6byWrEoDRpKL8+A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
@@ -2531,228 +2531,228 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
-      "integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
+      "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
-      "integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
+      "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
-      "integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
+      "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
-      "integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
+      "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
-      "integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
+      "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
-      "integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
+      "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
-      "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
+      "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
-      "integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
+      "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
-      "integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
+      "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
-      "integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
+      "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
-      "integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
+      "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
-      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
+      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
-      "integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
+      "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
-      "integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
+      "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
-      "integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
+      "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
-      "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
+      "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -3310,10 +3310,11 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/google.accounts": {
       "version": "0.0.14",
@@ -4055,57 +4056,57 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.20.2",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.20.2.tgz",
-      "integrity": "sha512-9d6Bs5ZKIV+JhB0eD7KxYnIfnhUh86kNtTGIuNiIxHFUhbuyT1DXN2SuMksDmtSfuRYZ82/C4hq+OJjWNNbmHg==",
+      "version": "5.21.4",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.21.4.tgz",
+      "integrity": "sha512-yMpwam1A4/RIIemJK0V3SpMAfgbBEM47OFzEYcEQPDP+B4ZAeviKOLaFFxUt/sxRCMeoALnJEK6Hb6qOqL0hbA==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.1.0",
-        "@ant-design/cssinjs": "^1.21.0",
-        "@ant-design/cssinjs-utils": "^1.0.3",
-        "@ant-design/icons": "^5.4.0",
+        "@ant-design/cssinjs": "^1.21.1",
+        "@ant-design/cssinjs-utils": "^1.1.1",
+        "@ant-design/icons": "^5.5.1",
         "@ant-design/react-slick": "~1.1.2",
-        "@babel/runtime": "^7.24.8",
+        "@babel/runtime": "^7.25.6",
         "@ctrl/tinycolor": "^3.6.1",
         "@rc-component/color-picker": "~2.0.1",
         "@rc-component/mutate-observer": "^1.1.0",
         "@rc-component/qrcode": "~1.0.0",
-        "@rc-component/tour": "~1.15.0",
-        "@rc-component/trigger": "^2.2.1",
+        "@rc-component/tour": "~1.15.1",
+        "@rc-component/trigger": "^2.2.3",
         "classnames": "^2.5.1",
         "copy-to-clipboard": "^3.3.3",
         "dayjs": "^1.11.11",
-        "rc-cascader": "~3.27.0",
+        "rc-cascader": "~3.28.1",
         "rc-checkbox": "~3.3.0",
-        "rc-collapse": "~3.7.3",
-        "rc-dialog": "~9.5.2",
+        "rc-collapse": "~3.8.0",
+        "rc-dialog": "~9.6.0",
         "rc-drawer": "~7.2.0",
         "rc-dropdown": "~4.2.0",
         "rc-field-form": "~2.4.0",
-        "rc-image": "~7.9.0",
+        "rc-image": "~7.11.0",
         "rc-input": "~1.6.3",
         "rc-input-number": "~9.2.0",
-        "rc-mentions": "~2.15.0",
-        "rc-menu": "~9.14.1",
-        "rc-motion": "^2.9.2",
-        "rc-notification": "~5.6.0",
-        "rc-pagination": "~4.2.0",
-        "rc-picker": "~4.6.13",
+        "rc-mentions": "~2.16.1",
+        "rc-menu": "~9.15.1",
+        "rc-motion": "^2.9.3",
+        "rc-notification": "~5.6.2",
+        "rc-pagination": "~4.3.0",
+        "rc-picker": "~4.6.15",
         "rc-progress": "~4.0.0",
         "rc-rate": "~2.13.0",
         "rc-resize-observer": "^1.4.0",
-        "rc-segmented": "~2.3.0",
-        "rc-select": "~14.15.1",
-        "rc-slider": "~11.1.5",
+        "rc-segmented": "~2.5.0",
+        "rc-select": "~14.15.2",
+        "rc-slider": "~11.1.7",
         "rc-steps": "~6.0.1",
         "rc-switch": "~4.1.0",
-        "rc-table": "~7.45.7",
-        "rc-tabs": "~15.1.1",
-        "rc-textarea": "~1.8.1",
-        "rc-tooltip": "~6.2.0",
-        "rc-tree": "~5.8.8",
-        "rc-tree-select": "~5.22.1",
-        "rc-upload": "~4.7.0",
+        "rc-table": "~7.47.5",
+        "rc-tabs": "~15.3.0",
+        "rc-textarea": "~1.8.2",
+        "rc-tooltip": "~6.2.1",
+        "rc-tree": "~5.9.0",
+        "rc-tree-select": "~5.23.0",
+        "rc-upload": "~4.8.1",
         "rc-util": "^5.43.0",
         "scroll-into-view-if-needed": "^3.1.0",
         "throttle-debounce": "^5.0.2"
@@ -4129,9 +4130,9 @@
       }
     },
     "node_modules/antd/node_modules/@ant-design/icons": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.4.0.tgz",
-      "integrity": "sha512-QZbWC5xQYexCI5q4/fehSEkchJr5UGtvAJweT743qKUQQGs9IH2DehNLP49DJ3Ii9m9CijD2HN6fNy3WKhIFdA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.5.1.tgz",
+      "integrity": "sha512-0UrM02MA2iDIgvLatWrj6YTCYe0F/cwXvVE0E2SqGrL7PZireQwgEKTKBisWpZyal5eXZLvuM98kju6YtYne8w==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
@@ -4149,9 +4150,9 @@
       }
     },
     "node_modules/antd/node_modules/rc-picker": {
-      "version": "4.6.13",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.6.13.tgz",
-      "integrity": "sha512-yi4JWPGjm420Q8rHjZ6YNy2c5IfV+9EAzx2pewVRPOjJqfg7uifO/Z0uqxdl/h6AhBocuvRvtlyz6ehrAvTq7A==",
+      "version": "4.6.15",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.6.15.tgz",
+      "integrity": "sha512-OWZ1yrMie+KN2uEUfYCfS4b2Vu6RC1FWwNI0s+qypsc3wRt7g+peuZKVIzXCTaJwyyZruo80+akPg2+GmyiJjw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
@@ -5081,11 +5082,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
-    },
-    "node_modules/d3-voronoi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
-      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg=="
     },
     "node_modules/dagre": {
       "version": "0.8.5",
@@ -8475,7 +8471,8 @@
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -9411,16 +9408,16 @@
       }
     },
     "node_modules/rc-cascader": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.27.0.tgz",
-      "integrity": "sha512-z5uq8VvQadFUBiuZJ7YF5UAUGNkZtdEtcEYiIA94N/Kc2MIKr6lEbN5HyVddvYSgwWlKqnL6pH5bFXFuIK3MNg==",
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.28.2.tgz",
+      "integrity": "sha512-8f+JgM83iLTvjgdkgU7GfI4qY8icXOBP0cGZjOdx2iJAkEe8ucobxDQAVE69UD/c3ehCxZlcgEHeD5hFmypbUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "array-tree-filter": "^2.1.0",
         "classnames": "^2.3.1",
         "rc-select": "~14.15.0",
-        "rc-tree": "~5.8.1",
+        "rc-tree": "~5.9.0",
         "rc-util": "^5.37.0"
       },
       "peerDependencies": {
@@ -9443,9 +9440,10 @@
       }
     },
     "node_modules/rc-collapse": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.7.3.tgz",
-      "integrity": "sha512-60FJcdTRn0X5sELF18TANwtVi7FtModq649H11mYF1jh83DniMoM4MqY627sEKRCTm4+WXfGDcB7hY5oW6xhyw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.8.0.tgz",
+      "integrity": "sha512-YVBkssrKPBG09TGfcWWGj8zJBYD9G3XuTy89t5iUmSXrIXEAnO1M+qjUxRW6b4Qi0+wNWG6MHJF/+US+nmIlzA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -9458,9 +9456,10 @@
       }
     },
     "node_modules/rc-dialog": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.5.2.tgz",
-      "integrity": "sha512-qVUjc8JukG+j/pNaHVSRa2GO2/KbV2thm7yO4hepQ902eGdYK913sGkwg/fh9yhKYV1ql3BKIN2xnud3rEXAPw==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
+      "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/portal": "^1.0.0-8",
@@ -9493,6 +9492,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.0.tgz",
       "integrity": "sha512-odM8Ove+gSh0zU27DUj5cG1gNKg7mLWBYzB5E4nNLrLwBmYEgYP43vHKDGOVZcJSVElQBI0+jTQgjnq0NfLjng==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@rc-component/trigger": "^2.0.0",
@@ -9523,14 +9523,15 @@
       }
     },
     "node_modules/rc-image": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.9.0.tgz",
-      "integrity": "sha512-l4zqO5E0quuLMCtdKfBgj4Suv8tIS011F5k1zBBlK25iMjjiNHxA0VeTzGFtUZERSA45gvpXDg8/P6qNLjR25g==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.11.0.tgz",
+      "integrity": "sha512-aZkTEZXqeqfPZtnSdNUnKQA0N/3MbgR7nUnZ+/4MfSFWPFHZau4p5r5ShaI0KPEMnNjv4kijSCFq/9wtJpwykw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@rc-component/portal": "^1.0.2",
         "classnames": "^2.2.6",
-        "rc-dialog": "~9.5.2",
+        "rc-dialog": "~9.6.0",
         "rc-motion": "^2.6.2",
         "rc-util": "^5.34.1"
       },
@@ -9572,16 +9573,16 @@
       }
     },
     "node_modules/rc-mentions": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.15.0.tgz",
-      "integrity": "sha512-f5v5i7VdqvBDXbphoqcQWmXDif2Msd2arritVoWybrVDuHE6nQ7XCYsybHbV//WylooK52BFDouFvyaRDtXZEw==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.16.1.tgz",
+      "integrity": "sha512-GnhSTGP9Mtv6pqFFGQze44LlrtWOjHNrUUAcsdo9DnNAhN4pwVPEWy4z+2jpjkiGlJ3VoXdvMHcNDQdfI9fEaw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "@rc-component/trigger": "^2.0.0",
         "classnames": "^2.2.6",
         "rc-input": "~1.6.0",
-        "rc-menu": "~9.14.0",
+        "rc-menu": "~9.15.1",
         "rc-textarea": "~1.8.0",
         "rc-util": "^5.34.1"
       },
@@ -9591,9 +9592,10 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.14.1.tgz",
-      "integrity": "sha512-5wlRb3M8S4yGlWhSoEYJ7ZVRElyScdcpUHxgiLxkeig1tEdyKrnED3B2fhpN0Rrpdp9jyhnmZR/Lwq2fH5VvDQ==",
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.15.1.tgz",
+      "integrity": "sha512-UKporqU6LPfHnpPmtP6hdEK4iO5Q+b7BRv/uRpxdIyDGplZy9jwUjsnpev5bs3PQKB0H0n34WAPDfjAfn3kAPA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/trigger": "^2.0.0",
@@ -9608,9 +9610,10 @@
       }
     },
     "node_modules/rc-motion": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.2.tgz",
-      "integrity": "sha512-fUAhHKLDdkAXIDLH0GYwof3raS58dtNUmzLF2MeiR8o6n4thNpSDQhOqQzWE4WfFZDCi9VEN8n7tiB7czREcyw==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.3.tgz",
+      "integrity": "sha512-rkW47ABVkic7WEB0EKJqzySpvDqwl60/tdkY7hWP7dYnh5pm0SzJpo54oW3TDUGXV5wfxXFmMkxrzRRbotQ0+w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -9622,9 +9625,10 @@
       }
     },
     "node_modules/rc-notification": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.0.tgz",
-      "integrity": "sha512-TGQW5T7waOxLwgJG7fXcw8l7AQiFOjaZ7ISF5PrU526nunHRNcTMuzKihQHaF4E/h/KfOCDk3Mv8eqzbu2e28w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.2.tgz",
+      "integrity": "sha512-Id4IYMoii3zzrG0lB0gD6dPgJx4Iu95Xu0BQrhHIbp7ZnAZbLqdqQ73aIWH0d0UFcElxwaKjnzNovTjo7kXz7g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -9655,9 +9659,9 @@
       }
     },
     "node_modules/rc-pagination": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-4.2.0.tgz",
-      "integrity": "sha512-V6qeANJsT6tmOcZ4XiUmj8JXjRLbkusuufpuoBw2GiAn94fIixYjFLmbruD1Sbhn8fPLDnWawPp4CN37zQorvw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-4.3.0.tgz",
+      "integrity": "sha512-UubEWA0ShnroQ1tDa291Fzw6kj0iOeF26IsUObxYTpimgj4/qPCWVFl18RLZE+0Up1IZg0IK4pMn6nB3mjvB7g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -9754,9 +9758,10 @@
       }
     },
     "node_modules/rc-segmented": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.3.0.tgz",
-      "integrity": "sha512-I3FtM5Smua/ESXutFfb8gJ8ZPcvFR+qUgeeGFQHBOvRiRKyAk4aBE5nfqrxXx+h8/vn60DQjOt6i4RNtrbOobg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.5.0.tgz",
+      "integrity": "sha512-B28Fe3J9iUFOhFJET3RoXAPFJ2u47QvLSYcZWC4tFYNGPEjug5LAxEasZlA/PpAxhdOPqGWsGbSj7ftneukJnw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -9769,9 +9774,9 @@
       }
     },
     "node_modules/rc-select": {
-      "version": "14.15.1",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.15.1.tgz",
-      "integrity": "sha512-mGvuwW1RMm1NCSI8ZUoRoLRK51R2Nb+QJnmiAvbDRcjh2//ulCkxeV6ZRFTECPpE1t2DPfyqZMPw90SVJzQ7wQ==",
+      "version": "14.15.2",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.15.2.tgz",
+      "integrity": "sha512-oNoXlaFmpqXYcQDzcPVLrEqS2J9c+/+oJuGrlXeVVX/gVgrbHa5YcyiRUXRydFjyuA7GP3elRuLF7Y3Tfwltlw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -9791,9 +9796,9 @@
       }
     },
     "node_modules/rc-slider": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.5.tgz",
-      "integrity": "sha512-b77H5PbjMKsvkYXAYIkn50QuFX6ICQmCTibDinI9q+BHx65/TV4TeU25+oadhSRzykxs0/vBWeKBwRyySOeWlg==",
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.7.tgz",
+      "integrity": "sha512-ytYbZei81TX7otdC0QvoYD72XSlxvTihNth5OeZ6PMXyEDq/vHdWFulQmfDGyXK1NwKwSlKgpvINOa88uT5g2A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -9840,15 +9845,16 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.45.7",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.45.7.tgz",
-      "integrity": "sha512-wi9LetBL1t1csxyGkMB2p3mCiMt+NDexMlPbXHvQFmBBAsMxrgNSAPwUci2zDLUq9m8QdWc1Nh8suvrpy9mXrg==",
+      "version": "7.47.5",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.47.5.tgz",
+      "integrity": "sha512-fzq+V9j/atbPIcvs3emuclaEoXulwQpIiJA6/7ey52j8+9cJ4P8DGmp4YzfUVDrb3qhgedcVeD6eRgUrokwVEQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/context": "^1.4.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.37.0",
+        "rc-util": "^5.41.0",
         "rc-virtual-list": "^3.14.2"
       },
       "engines": {
@@ -9860,14 +9866,15 @@
       }
     },
     "node_modules/rc-tabs": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.1.1.tgz",
-      "integrity": "sha512-Tc7bJvpEdkWIVCUL7yQrMNBJY3j44NcyWS48jF/UKMXuUlzaXK+Z/pEL5LjGcTadtPvVmNqA40yv7hmr+tCOAw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.3.0.tgz",
+      "integrity": "sha512-lzE18r+zppT/jZWOAWS6ntdkDUKHOLJzqMi5UAij1LeKwOaQaupupAoI9Srn73GRzVpmGznkECMRrzkRusC40A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
         "rc-dropdown": "~4.2.0",
-        "rc-menu": "~9.14.0",
+        "rc-menu": "~9.15.1",
         "rc-motion": "^2.6.2",
         "rc-resize-observer": "^1.0.0",
         "rc-util": "^5.34.1"
@@ -9881,9 +9888,9 @@
       }
     },
     "node_modules/rc-textarea": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.8.1.tgz",
-      "integrity": "sha512-bm36N2ZqwZAP60ZQg2OY9mPdqWC+m6UTjHc+CqEZOxb3Ia29BGHazY/s5bI8M4113CkqTzhtFUDNA078ZiOx3Q==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.8.2.tgz",
+      "integrity": "sha512-UFAezAqltyR00a8Lf0IPAyTd29Jj9ee8wt8DqXyDMal7r/Cg/nDt3e1OOv3Th4W6mKaZijjgwuPXhAfVNTN8sw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -9898,9 +9905,10 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.2.0.tgz",
-      "integrity": "sha512-iS/3iOAvtDh9GIx1ulY7EFUXUtktFccNLsARo3NPgLf0QW9oT0w3dA9cYWlhqAKmD+uriEwdWz1kH0Qs4zk2Aw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.2.1.tgz",
+      "integrity": "sha512-rws0duD/3sHHsD905Nex7FvoUGy2UBQRhTkKxeEvr2FB+r21HsOxcDJI0TzyO8NHhnAA8ILr8pfbSBg5Jj5KBg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@rc-component/trigger": "^2.0.0",
@@ -9912,9 +9920,9 @@
       }
     },
     "node_modules/rc-tree": {
-      "version": "5.8.8",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.8.8.tgz",
-      "integrity": "sha512-S+mCMWo91m5AJqjz3PdzKilGgbFm7fFJRFiTDOcoRbD7UfMOPnerXwMworiga0O2XIo383UoWuEfeHs1WOltag==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.9.0.tgz",
+      "integrity": "sha512-CPrgOvm9d/9E+izTONKSngNzQdIEjMox2PBufWjS1wf7vxtvmCWzK1SlpHbRY6IaBfJIeZ+88RkcIevf729cRg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -9932,15 +9940,15 @@
       }
     },
     "node_modules/rc-tree-select": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.22.1.tgz",
-      "integrity": "sha512-b8mAK52xEpRgS+b2PTapCt29GoIrO5cO8jB7AfHttFsIJfcnynY9FCtnYzURsKXJkGHbFY6UzSEB2I3TETtdWg==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.23.0.tgz",
+      "integrity": "sha512-aQGi2tFSRw1WbXv0UVXPzHm09E0cSvUVZMLxQtMv3rnZZpNmdRXWrnd9QkLNlVH31F+X5rgghmdSFF3yZW0N9A==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
         "rc-select": "~14.15.0",
-        "rc-tree": "~5.8.1",
+        "rc-tree": "~5.9.0",
         "rc-util": "^5.16.1"
       },
       "peerDependencies": {
@@ -9949,9 +9957,9 @@
       }
     },
     "node_modules/rc-upload": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.7.0.tgz",
-      "integrity": "sha512-eUwxYNHlsYe5vYhKFAUGrQG95JrnPzY+BmPi1Daq39fWNl/eOc7v4UODuWrVp2LFkQBuV3cMCG/I68iub6oBrg==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.8.1.tgz",
+      "integrity": "sha512-toEAhwl4hjLAI1u8/CgKWt30BR06ulPa4iGQSMvSXoHzO88gPCslxqV/mnn4gJU7PDoltGIC9Eh+wkeudqgHyw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -9977,9 +9985,10 @@
       }
     },
     "node_modules/rc-virtual-list": {
-      "version": "3.14.5",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.14.5.tgz",
-      "integrity": "sha512-ZMOnkCLv2wUN8Jz7yI4XiSLa9THlYvf00LuMhb1JlsQCewuU7ydPuHw1rGVPhe9VZYl/5UqODtNd7QKJ2DMGfg==",
+      "version": "3.14.8",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.14.8.tgz",
+      "integrity": "sha512-8D0KfzpRYi6YZvlOWIxiOm9BGt4Wf2hQyEaM6RXlDDiY2NhLheuYI+RA+7ZaZj1lq+XQqy3KHlaeeXQfzI5fGg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "classnames": "^2.2.6",
@@ -11763,10 +11772,11 @@
       }
     },
     "node_modules/vite-plugin-eslint/node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -11814,14 +11824,15 @@
       }
     },
     "node_modules/vite-plugin-svgr/node_modules/rollup": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
-      "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
+      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -11831,248 +11842,24 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.18.0",
-        "@rollup/rollup-android-arm64": "4.18.0",
-        "@rollup/rollup-darwin-arm64": "4.18.0",
-        "@rollup/rollup-darwin-x64": "4.18.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.18.0",
-        "@rollup/rollup-linux-arm64-musl": "4.18.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-gnu": "4.18.0",
-        "@rollup/rollup-linux-x64-musl": "4.18.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.18.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.18.0",
-        "@rollup/rollup-win32-x64-msvc": "4.18.0",
+        "@rollup/rollup-android-arm-eabi": "4.24.0",
+        "@rollup/rollup-android-arm64": "4.24.0",
+        "@rollup/rollup-darwin-arm64": "4.24.0",
+        "@rollup/rollup-darwin-x64": "4.24.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
+        "@rollup/rollup-linux-arm64-musl": "4.24.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-musl": "4.24.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
+        "@rollup/rollup-win32-x64-msvc": "4.24.0",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.0.tgz",
-      "integrity": "sha512-/IZQvg6ZR0tAkEi4tdXOraQoWeJy9gbQ/cx4I7k9dJaCk9qrXEcdouxRVz5kZXt5C2bQ9pILoAA+KB4C/d3pfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.0.tgz",
-      "integrity": "sha512-ETHi4bxrYnvOtXeM7d4V4kZWixib2jddFacJjsOjwbgYSRsyXYtZHC4ht134OsslPIcnkqT+TKV4eU8rNBKyyQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.0.tgz",
-      "integrity": "sha512-ZWgARzhSKE+gVUX7QWaECoRQsPwaD8ZR0Oxb3aUpzdErTvlEadfQpORPXkKSdKbFci9v8MJfkTtoEHnnW9Ulng==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.0.tgz",
-      "integrity": "sha512-h0ZAtOfHyio8Az6cwIGS+nHUfRMWBDO5jXB8PQCARVF6Na/G6XS2SFxDl8Oem+S5ZsHQgtsI7RT4JQnI1qrlaw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.0.tgz",
-      "integrity": "sha512-9pxQJSPwFsVi0ttOmqLY4JJ9pg9t1gKhK0JDbV1yUEETSx55fdyCjt39eBQ54OQCzAF0nVGO6LfEH1KnCPvelA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.0.tgz",
-      "integrity": "sha512-YJ5Ku5BmNJZb58A4qSEo3JlIG4d3G2lWyBi13ABlXzO41SsdnUKi3HQHe83VpwBVG4jHFTW65jOQb8qyoR+qzg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.0.tgz",
-      "integrity": "sha512-U4G4u7f+QCqHlVg1Nlx+qapZy+QoG+NV6ux+upo/T7arNGwKvKP2kmGM4W5QTbdewWFgudQxi3kDNST9GT1/mg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.0.tgz",
-      "integrity": "sha512-aQpNlKmx3amwkA3a5J6nlXSahE1ijl0L9KuIjVOUhfOh7uw2S4piR3mtpxpRtbnK809SBtyPsM9q15CPTsY7HQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.0.tgz",
-      "integrity": "sha512-9fx6Zj/7vve/Fp4iexUFRKb5+RjLCff6YTRQl4CoDhdMfDoobWmhAxQWV3NfShMzQk1Q/iCnageFyGfqnsmeqQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.0.tgz",
-      "integrity": "sha512-VWQiCcN7zBgZYLjndIEh5tamtnKg5TGxyZPWcN9zBtXBwfcGSZ5cHSdQZfQH/GB4uRxk0D3VYbOEe/chJhPGLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.0.tgz",
-      "integrity": "sha512-EHmPnPWvyYqncObwqrosb/CpH3GOjE76vWVs0g4hWsDRUVhg61hBmlVg5TPXqF+g+PvIbqkC7i3h8wbn4Gp2Fg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.0.tgz",
-      "integrity": "sha512-tsSWy3YQzmpjDKnQ1Vcpy3p9Z+kMFbSIesCdMNgLizDWFhrLZIoN21JSq01g+MZMDFF+Y1+4zxgrlqPjid5ohg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.0.tgz",
-      "integrity": "sha512-anr1Y11uPOQrpuU8XOikY5lH4Qu94oS6j0xrulHk3NkLDq19MlX8Ng/pVipjxBJ9a2l3+F39REZYyWQFkZ4/fw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.0.tgz",
-      "integrity": "sha512-7LB+Bh+Ut7cfmO0m244/asvtIGQr5pG5Rvjz/l1Rnz1kDzM02pSX9jPaS0p+90H5I1x4d1FkCew+B7MOnoatNw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.0.tgz",
-      "integrity": "sha512-+3qZ4rer7t/QsC5JwMpcvCVPRcJt1cJrYS/TMJZzXIJbxWFQEVhrIc26IhB+5Z9fT9umfVc+Es2mOZgl+7jdJQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.0.tgz",
-      "integrity": "sha512-YdicNOSJONVx/vuPkgPTyRoAPx3GbknBZRCOUkK84FJ/YTfs/F0vl/YsMscrB6Y177d+yDRcj+JWMPMCgshwrA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/vite/node_modules/postcss": {
       "version": "8.4.47",
@@ -12104,13 +11891,13 @@
       }
     },
     "node_modules/vite/node_modules/rollup": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.0.tgz",
-      "integrity": "sha512-W21MUIFPZ4+O2Je/EU+GP3iz7PH4pVPUXSbEZdatQnxo29+3rsUjgrJmzuAZU24z7yRAnFN6ukxeAhZh/c7hzg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
+      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -12120,22 +11907,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.22.0",
-        "@rollup/rollup-android-arm64": "4.22.0",
-        "@rollup/rollup-darwin-arm64": "4.22.0",
-        "@rollup/rollup-darwin-x64": "4.22.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.22.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.22.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.22.0",
-        "@rollup/rollup-linux-arm64-musl": "4.22.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.22.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.22.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.22.0",
-        "@rollup/rollup-linux-x64-gnu": "4.22.0",
-        "@rollup/rollup-linux-x64-musl": "4.22.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.22.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.22.0",
-        "@rollup/rollup-win32-x64-msvc": "4.22.0",
+        "@rollup/rollup-android-arm-eabi": "4.24.0",
+        "@rollup/rollup-android-arm64": "4.24.0",
+        "@rollup/rollup-darwin-arm64": "4.24.0",
+        "@rollup/rollup-darwin-x64": "4.24.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
+        "@rollup/rollup-linux-arm64-musl": "4.24.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-musl": "4.24.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
+        "@rollup/rollup-win32-x64-msvc": "4.24.0",
         "fsevents": "~2.3.2"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "@rive-app/react-canvas": "4.8.3",
     "@tanstack/react-query": "5.29.2",
     "@tippyjs/react": "4.2.6",
-    "antd": "5.20.2",
+    "antd": "5.21.4",
     "axios": "1.7.7",
     "dayjs": "1.11.11",
     "fast-fuzzy": "1.12.0",

--- a/frontend/src/components/MigrationModal/MigrationModal.tsx
+++ b/frontend/src/components/MigrationModal/MigrationModal.tsx
@@ -1,0 +1,105 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Modal } from 'antd';
+import { importUser as importUserApi } from 'utils/api/userApi';
+import { importUser, UserJson } from 'utils/export';
+import openNotification from 'utils/openNotification';
+import useToken from 'hooks/useToken';
+import { resetTabs } from 'reducers/courseTabsSlice';
+import { resetSettings } from 'reducers/settingsSlice';
+
+type Props = {
+  open?: boolean;
+  onOk?: () => void; // runs after resetting the data
+  onCancel?: () => void;
+};
+
+function migrationErrorNotification() {
+  openNotification({
+    type: 'error',
+    message: 'Migration failed',
+    description:
+      'An error occurred whilst migrating your data. Either try again, reset your data, or download your data and attempt to import it again/contact DevSoc for help.'
+  });
+}
+
+const MigrationModal = ({ open, onOk, onCancel }: Props) => {
+  const dispatch = useDispatch();
+  const token = useToken();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const importUserMutation = useMutation({
+    mutationFn: (user: UserJson) => importUserApi(token, user),
+    onSuccess: () => {
+      localStorage.removeItem('oldUser');
+      queryClient.resetQueries();
+      navigate('/course-selector');
+      onOk?.();
+    },
+    onError: () => {
+      migrationErrorNotification();
+    }
+  });
+
+  const clearOldUser = () => {
+    localStorage.removeItem('oldUser');
+    dispatch(resetSettings());
+    dispatch(resetTabs());
+    onCancel?.();
+  };
+
+  const handleMigration = async () => {
+    try {
+      const user = importUser(JSON.parse(localStorage.getItem('oldUser')!) as JSON);
+      importUserMutation.mutate(user);
+    } catch (error) {
+      migrationErrorNotification();
+    }
+  };
+
+  const download = () => {
+    const blob = new Blob([localStorage.getItem('oldUser')!], { type: 'application/json' });
+    const jsonObjectUrl = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = jsonObjectUrl;
+    const date = new Date();
+    a.download = `circles-planner-export-${date.toISOString()}.json`;
+    a.click();
+  };
+
+  return (
+    <Modal
+      title="Local Circles Data Detected"
+      open={open ?? false}
+      closable={false}
+      onOk={handleMigration}
+      okButtonProps={{ type: 'primary' }}
+      okText="Migrate Old Data"
+      onCancel={clearOldUser}
+      cancelText="Clear Old Data"
+      cancelButtonProps={{ type: 'primary', danger: true }}
+      mask
+      maskClosable={false}
+      keyboard={false}
+    >
+      <div>
+        <p>
+          As you may have noticed, Circles moved to a login system. We&apos;ve detected an old
+          planner saved locally, and can attempt to migrate it for you. You can also{' '}
+          <a onClick={download}>download</a> it for importing later.
+        </p>
+        <p>
+          If you&apos;re signed in as a guest, you may wish to <a href="/logout">logout</a> and sign
+          in with your zID to save your data in the long term.
+        </p>
+      </div>
+    </Modal>
+  );
+};
+
+export default MigrationModal;

--- a/frontend/src/components/MigrationModal/MigrationModal.tsx
+++ b/frontend/src/components/MigrationModal/MigrationModal.tsx
@@ -74,7 +74,7 @@ const MigrationModal = ({ open, onOk, onCancel }: Props) => {
 
   return (
     <Modal
-      title="Local Circles Data Detected"
+      title="Local Circles Data Detected (Pre Nov 2024)"
       open={open ?? false}
       closable={false}
       onOk={handleMigration}
@@ -89,8 +89,8 @@ const MigrationModal = ({ open, onOk, onCancel }: Props) => {
     >
       <div>
         <p>
-          As you may have noticed, Circles moved to a login system. We&apos;ve detected an old
-          planner saved locally, and can attempt to migrate it for you. You can also{' '}
+          As you may have noticed, Circles moved to a login system in 2024 Term 3. We&apos;ve
+          detected an old planner saved locally, and can attempt to migrate it for you. You can also{' '}
           <a onClick={download}>download</a> it for importing later.
         </p>
         <p>

--- a/frontend/src/components/MigrationModal/index.ts
+++ b/frontend/src/components/MigrationModal/index.ts
@@ -1,0 +1,3 @@
+import MigrationModal from './MigrationModal';
+
+export default MigrationModal;

--- a/frontend/src/config/store.ts
+++ b/frontend/src/config/store.ts
@@ -22,7 +22,7 @@ export const persistConfig = {
   key: 'root',
   version: persistVersion,
   storage,
-  whitelist: ['degree', 'courses', 'planner', 'settings'],
+  whitelist: ['settings'],
   migrate: persistMigrate
 };
 

--- a/frontend/src/pages/DegreeWizard/DegreeWizard.tsx
+++ b/frontend/src/pages/DegreeWizard/DegreeWizard.tsx
@@ -7,6 +7,7 @@ import { DegreeWizardPayload } from 'types/degreeWizard';
 import { getSpecialisationTypes } from 'utils/api/specsApi';
 import { getUserIsSetup, resetUserDegree } from 'utils/api/userApi';
 import openNotification from 'utils/openNotification';
+import MigrationModal from 'components/MigrationModal';
 import PageTemplate from 'components/PageTemplate';
 import ResetModal from 'components/ResetModal';
 import useToken from 'hooks/useToken';
@@ -101,11 +102,18 @@ const DegreeWizard = () => {
     navigate('/logout');
   };
 
+  const [migrationNeeded, setMigrationNeeded] = useState(localStorage.getItem('oldUser') !== null);
+
   return (
     <PageTemplate showHeader={false} showBugButton={false}>
       <S.ContainerWrapper>
+        <MigrationModal
+          open={migrationNeeded}
+          onOk={() => setMigrationNeeded(false)}
+          onCancel={() => setMigrationNeeded(false)}
+        />
         <ResetModal
-          open={isSetup}
+          open={isSetup && !migrationNeeded}
           onCancel={() => navigate('/course-selector')}
           onOk={() => resetDegree.mutate()}
         />

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getUserIsSetup } from 'utils/api/userApi';
+import { importUser } from 'utils/export';
 import PageLoading from 'components/PageLoading';
 import { inDev } from 'config/constants';
 import useToken from 'hooks/useToken';
@@ -13,6 +15,23 @@ import KeyFeaturesSection from './KeyFeaturesSection';
 import SponsorSection from './SponsorSection';
 
 const LandingPage = () => {
+  // THIS IS FOR MIGRATION. DELETE WHEN MIGRATION IS DONE
+  const [searchParams, setSearchParams] = useSearchParams();
+  const migration = searchParams.get('migration');
+  if (migration) {
+    try {
+      const json = JSON.parse(migration) as JSON;
+      // Throws error if migration is bad
+      importUser(json);
+      localStorage.setItem('oldUser', migration);
+    } catch {
+      // eslint-disable-next-line no-console
+      console.error('Bad migration query param');
+    }
+    setSearchParams({});
+  }
+  // END OF MIGRATION CODE
+
   // determine our next location
   const token = useToken({ allowUnset: true });
 

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -23,12 +23,18 @@ const LandingPage = () => {
       const json = JSON.parse(migration) as JSON;
       // Throws error if migration is bad
       importUser(json);
-      localStorage.setItem('oldUser', migration);
+      if (localStorage.getItem('oldUser') === null) {
+        localStorage.setItem('oldUser', migration);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('oldUser already exists');
+      }
     } catch {
       // eslint-disable-next-line no-console
       console.error('Bad migration query param');
     }
     setSearchParams({});
+    window.history.replaceState({}, document.title, window.location.pathname);
   }
   // END OF MIGRATION CODE
 

--- a/frontend/src/reducers/settingsSlice.ts
+++ b/frontend/src/reducers/settingsSlice.ts
@@ -19,6 +19,7 @@ const settingsSlice = createSlice({
   name: 'settings',
   initialState: initialSettingsState,
   reducers: {
+    resetSettings: () => initialSettingsState,
     toggleTheme: (state, action: PayloadAction<Theme>) => {
       state.theme = action.payload;
     },
@@ -31,6 +32,7 @@ const settingsSlice = createSlice({
   }
 });
 
-export const { toggleTheme, toggleLockedCourses, toggleShowPastWarnings } = settingsSlice.actions;
+export const { resetSettings, toggleTheme, toggleLockedCourses, toggleShowPastWarnings } =
+  settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/frontend/src/utils/export.ts
+++ b/frontend/src/utils/export.ts
@@ -19,7 +19,7 @@ export type UserJson = {
 
 const settingsSchema = z.strictObject({
   showMarks: z.boolean(),
-  hiddenYears: z.array(z.number().int().positive())
+  hiddenYears: z.array(z.number().int().nonnegative())
 });
 
 const degreeSchema = z.strictObject({
@@ -28,16 +28,16 @@ const degreeSchema = z.strictObject({
 });
 
 const plannerSchema = z.strictObject({
-  unplanned: z.array(z.string()),
+  unplanned: z.array(z.string().length(8)),
   startYear: z.number().int().gte(2019),
   isSummerEnabled: z.boolean(),
   lockedTerms: z.record(z.string(), z.boolean()),
-  years: z.array(z.record(z.string(), z.array(z.string())))
+  years: z.array(z.record(z.string(), z.array(z.string().length(8))))
 });
 
 const courseSchema = z.strictObject({
   mark: z
-    .union([z.number().positive().int(), z.enum(['SY', 'FL', 'PS', 'CR', 'DN', 'HD'])])
+    .union([z.number().nonnegative().int(), z.enum(['SY', 'FL', 'PS', 'CR', 'DN', 'HD'])])
     .nullable(),
   ignoreFromProgression: z.boolean()
 });
@@ -46,7 +46,7 @@ const exportOutputSchema = z.strictObject({
   settings: settingsSchema,
   degree: degreeSchema,
   planner: plannerSchema,
-  courses: z.record(z.string(), courseSchema)
+  courses: z.record(z.string().length(8), courseSchema)
 });
 
 export const exportUser = (user: UserResponse): UserJson => {

--- a/frontend/src/utils/export.ts
+++ b/frontend/src/utils/export.ts
@@ -19,17 +19,17 @@ export type UserJson = {
 
 const settingsSchema = z.strictObject({
   showMarks: z.boolean(),
-  hiddenYears: z.array(z.number())
+  hiddenYears: z.array(z.number().int().positive())
 });
 
 const degreeSchema = z.strictObject({
-  programCode: z.string(),
+  programCode: z.string().length(4),
   specs: z.array(z.string())
 });
 
 const plannerSchema = z.strictObject({
   unplanned: z.array(z.string()),
-  startYear: z.number(),
+  startYear: z.number().int().gte(2019),
   isSummerEnabled: z.boolean(),
   lockedTerms: z.record(z.string(), z.boolean()),
   years: z.array(z.record(z.string(), z.array(z.string())))
@@ -68,7 +68,7 @@ export const exportUser = (user: UserResponse): UserJson => {
   };
 };
 
-export const importUser = (data: JSON) => {
+export const importUser = (data: JSON): UserJson => {
   const parsed = exportOutputSchema.safeParse(data);
   if (!parsed.success || parsed.data === undefined) {
     parsed.error.errors.forEach((err) => {


### PR DESCRIPTION
Resolves #1172 

- Add Redux migrator that moves local storage user data from `persist:root` into `oldUser`
- Add functionality in Degree Wizard to import from, download, or clear `oldUser`
- Add support for the `migration` query parameter on the landing page, which given a valid `UserJson` type as a JSON string, will write it to `oldUser` on page load, allowing for `circles.csesoc.app` to redirect to `circles.devsoc.app` with the converted data in the URL, and then the existing migration flow via Degree Wizard to be followed

All tested locally but please please please test it more! Thanks. Also I bumped `antd` for new link style. Seems fine and changelog didn't indicate any breaking changes we needed to worry about.