### PR TITLE
fix(frontend): Fix links to sponsor sites

### DIFF
--- a/frontend/src/pages/LandingPage/SponsorSection/SponsorSection.tsx
+++ b/frontend/src/pages/LandingPage/SponsorSection/SponsorSection.tsx
@@ -106,7 +106,8 @@ const SponsorSection = () => {
 
   const renderLogos = (logoUrls: string[], tier: LogoProps['size']) =>
     logoUrls.map((url) => {
-      const fileName = url.split('/').pop()?.split('.')[0] || '';
+      // Necessary to split on '-' as in production some tags are added to the image
+      const fileName = url.split('/').pop()?.split('.')[0].split('-')[0] || '';
       return (
         <Logo
           key={`${tier}-${url}`}


### PR DESCRIPTION
Previously, the sponser logos would not properly link to their corresponding sites. This was due to a reliance on the names of logo files which were altered in production.

This change accounts for such.