### PR TITLE
fix(lp): changed the color of text from white to black on lightmode

### DIFF
--- a/frontend/src/pages/LandingPage/Hero/HeroContent/HeroContent.tsx
+++ b/frontend/src/pages/LandingPage/Hero/HeroContent/HeroContent.tsx
@@ -4,6 +4,7 @@ import { ArrowRightOutlined } from '@ant-design/icons';
 import { Space } from 'antd';
 import devsocLogo from 'assets/devsocLogo.svg';
 import easySubTitle from 'assets/LandingPage/easySubtitle.svg';
+import useSettings from 'hooks/useSettings';
 import S from './styles';
 
 type Props = {
@@ -11,9 +12,14 @@ type Props = {
 };
 
 const HeroContent = ({ startLocation }: Props) => {
+  const { theme } = useSettings();
   return (
     <S.HeroContent>
-      <S.HeroTitle animate={{ x: [-60, 10, 0] }} transition={{ duration: 1, ease: 'easeInOut' }}>
+      <S.HeroTitle
+        themeMode={theme}
+        animate={{ x: [-60, 10, 0] }}
+        transition={{ duration: 1, ease: 'easeInOut' }}
+      >
         Degree planning made <S.HeroSubTitle src={easySubTitle} alt="Hero Subtitle" />
       </S.HeroTitle>
       <Link to={startLocation}>

--- a/frontend/src/pages/LandingPage/Hero/HeroContent/styles.ts
+++ b/frontend/src/pages/LandingPage/Hero/HeroContent/styles.ts
@@ -9,8 +9,8 @@ const HeroContent = styled.div`
   }
 `;
 
-const HeroTitle = motion(styled.h1`
-  color: #fff;
+export const HeroTitle = motion(styled.h1<{ themeMode: string }>`
+  color: ${({ themeMode }) => (themeMode === 'dark' ? '#fff' : '#000')};
   line-height: 1.2;
   font-size: 70px;
   font-weight: 650;

--- a/frontend/src/pages/LandingPage/Hero/HeroHeader/HeroHeader.tsx
+++ b/frontend/src/pages/LandingPage/Hero/HeroHeader/HeroHeader.tsx
@@ -1,17 +1,26 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import circlesLogo from 'assets/circlesLogo.svg';
+import useSettings from 'hooks/useSettings';
 import S from './styles';
 
-const HeroHeader = () => (
-  <S.Header animate={{ y: 0 }} initial={{ y: -40 }} transition={{ duration: 0.5, ease: 'easeOut' }}>
-    <Link to="/">
-      <S.LogoWrapper>
-        <S.HeaderLogo src={circlesLogo} alt="Circles Logo" />
-        <S.HeaderTitle>Circles</S.HeaderTitle>
-      </S.LogoWrapper>
-    </Link>
-  </S.Header>
-);
+const HeroHeader = () => {
+  const { theme } = useSettings();
+
+  return (
+    <S.Header
+      animate={{ y: 0 }}
+      initial={{ y: -40 }}
+      transition={{ duration: 0.5, ease: 'easeOut' }}
+    >
+      <Link to="/">
+        <S.LogoWrapper>
+          <S.HeaderLogo src={circlesLogo} alt="Circles Logo" />
+          <S.HeaderTitle themeMode={theme}>Circles</S.HeaderTitle>
+        </S.LogoWrapper>
+      </Link>
+    </S.Header>
+  );
+};
 
 export default HeroHeader;

--- a/frontend/src/pages/LandingPage/Hero/HeroHeader/styles.ts
+++ b/frontend/src/pages/LandingPage/Hero/HeroHeader/styles.ts
@@ -44,8 +44,8 @@ const HeaderLogo = styled.img`
   width: 40px;
 `;
 
-const HeaderTitle = styled.h1`
-  color: #fff;
+const HeaderTitle = styled.h1<{ themeMode: string }>`
+  color: ${({ themeMode }) => (themeMode === 'dark' ? '#fff' : '#000')};
   font-size: 26px;
 `;
 


### PR DESCRIPTION
- Previously could not see text on the landing page and header if on light mode
- Changed the text color to be white if dark mode, and otherwise it should be black

![image](https://github.com/user-attachments/assets/030d45a7-c211-4d48-a34b-68f619aff2b7)
- Currently cannot see white text on lightmode