### PR TITLE
fix (tp): added defensive checking when accessing course in tp

### DIFF
--- a/frontend/src/pages/TermPlanner/TermBox/TermBox.tsx
+++ b/frontend/src/pages/TermPlanner/TermBox/TermBox.tsx
@@ -56,7 +56,10 @@ const TermBox = ({
     toggleLockTermMutation.mutate({ term, year });
   };
 
-  const termUOC = termCourseCodes.reduce((acc, code) => acc + termCourseInfos[code].UOC, 0);
+  const termUOC = termCourseCodes.reduce((acc, code) => {
+    const course = termCourseInfos[code];
+    return acc + (course ? course.UOC : 0);
+  }, 0);
 
   const isLocked: boolean = planner.lockedTerms[`${year}${term}`] ?? false;
   const offeredInTerm =
@@ -97,9 +100,10 @@ const TermBox = ({
               {...provided.droppableProps}
             >
               {Object.values(termCourseInfos).map((info, index) => {
+                if (!info || !courseInfos[info.code]) return null;
                 return (
                   <DraggableCourse
-                    key={`${info.title || ''}${term}`}
+                    key={`${info.title || info.code || ''}${term}`}
                     planner={planner}
                     courses={courses}
                     validate={validateInfos[info.code]}

--- a/frontend/src/pages/TermPlanner/UnplannedColumn/UnplannedColumn.tsx
+++ b/frontend/src/pages/TermPlanner/UnplannedColumn/UnplannedColumn.tsx
@@ -46,17 +46,21 @@ const UnplannedColumn = ({ dragging, courseInfos, validateInfos }: Props) => {
               $droppable={dragging}
               $isSmall={isSmall}
             >
-              {unplanned.map((courseCode, courseIndex) => (
-                <DraggableCourse
-                  key={courseCode}
-                  planner={planner}
-                  courses={courses}
-                  validate={validateInfos[courseCode]}
-                  courseInfo={courseInfos[courseCode]}
-                  index={courseIndex}
-                  time={undefined}
-                />
-              ))}
+              {unplanned.map((courseCode, courseIndex) => {
+                const info = courseInfos[courseCode];
+                if (!info) return null;
+                return (
+                  <DraggableCourse
+                    key={courseCode}
+                    planner={planner}
+                    courses={courses}
+                    validate={validateInfos[courseCode]}
+                    courseInfo={info}
+                    index={courseIndex}
+                    time={undefined}
+                  />
+                );
+              })}
               {provided.placeholder}
             </S.UnplannedBox>
           )}


### PR DESCRIPTION
after removing a course which was already in the planner or a course that was in the unplanned column, it would still be passed in the props, and would result in a crash