### PR TITLE
(Feat) Enable FE unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,6 @@ jobs:
   frontend_tests:
     name: Frontend Unit Tests
     runs-on: ubuntu-latest
-    if: false
     steps:
       - name: Checking out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
They were disabled after 331 merge, don't know why. This PR is threefold: 1. Active FE unittests, 2. See why they fail, 3. Fix them

Edit: Found out why; they don't pass