### PR TITLE
chore(ci): remove staging from docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,6 @@ on:
   push:
     branches:
       - dev
-      - staging
-
-env:
-  ENVIRONMENT: ${{ github.ref_name == 'dev' && 'prod' || 'staging' }}
-  IMAGE_NAME: ${{ github.ref_name == 'dev' && 'circles' || 'circles-staging' }}
 
 jobs:
   build:
@@ -51,8 +46,8 @@ jobs:
           file: ${{ matrix.component }}/${{ matrix.dockerfile }}
           build-args: ${{ matrix.args }}
           tags: |
-            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME}}-${{ matrix.component }}:${{ github.sha }}
-            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME}}-${{ matrix.component }}:latest
+            ghcr.io/devsoc-unsw/circles-${{ matrix.component }}:${{ github.sha }}
+            ghcr.io/devsoc-unsw/circles-${{ matrix.component }}:latest
           labels: ${{ steps.meta.outputs.labels }}
   deploy:
     name: Deploy (CD)
@@ -69,5 +64,5 @@ jobs:
           deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
           deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
           updates: |
-            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-frontend=${{ github.sha }}
-            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-backend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/circles-frontend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/circles-backend=${{ github.sha }}


### PR DESCRIPTION
## Summary
- remove the staging push trigger from the Docker workflow
- replace branch-based image naming with the production circles image names
- keep deployment dispatch updates targeting the production circles images only