### PR TITLE
ci(docker): point staging frontend build at circlesstagingapi.devsoc.app

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
           - component: frontend
             dockerfile: production.dockerfile
             args: |
-              "API_URL=https://circlesapi.devsoc.app"
+              "API_URL=${{ github.ref_name == 'dev' && 'https://circlesapi.devsoc.app' || 'https://circlesstagingapi.devsoc.app' }}"
           - component: backend
             dockerfile: production.dockerfile
     steps:


### PR DESCRIPTION
## Summary

The Docker workflow always passed `API_URL=https://circlesapi.devsoc.app` when building the frontend image, including for pushes to `staging`. That baked the production API into the staging frontend image.

## Change

- **`dev` branch builds:** unchanged — `https://circlesapi.devsoc.app`
- **`staging` branch builds:** `https://circlesstagingapi.devsoc.app`

The value is selected with `github.ref_name` so the correct URL is embedded at build time (`VITE_BACKEND_API_BASE_URL` via `production.dockerfile`).

Made with [Cursor](https://cursor.com)