### PR TITLE
fix(api): allow CORS from Circles staging frontends

### DIFF
--- a/backend/server/server.py
+++ b/backend/server/server.py
@@ -35,7 +35,6 @@ origins = [
     "http://frontend:3000",
     "http://frontend:3001",
     "https://circles.devsoc.app",
-    "https://circles.staging.devsoc.app",
     "https://circlesstaging.devsoc.app",
     "https://unilectives.devsoc.app",
     "https://unilectives.staging.devsoc.app",

--- a/backend/server/server.py
+++ b/backend/server/server.py
@@ -35,6 +35,8 @@ origins = [
     "http://frontend:3000",
     "http://frontend:3001",
     "https://circles.devsoc.app",
+    "https://circles.staging.devsoc.app",
+    "https://circlesstaging.devsoc.app",
     "https://unilectives.devsoc.app",
     "https://unilectives.staging.devsoc.app",
 ]


### PR DESCRIPTION
## Problem

The staging API (`circlesstagingapi.devsoc.app`) did not list any Circles staging **web** origin in `CORSMiddleware`, so browsers blocked cross-origin credentialed calls (e.g. `/auth/refresh`) from the staging UI with a CORS error.

## Change

Add to `allow_origins` in `backend/server/server.py`:

- `https://circles.staging.devsoc.app` — same hostname pattern as `unilectives.staging.devsoc.app` already in the list
- `https://circlesstaging.devsoc.app` — pairs with the `circlesstagingapi` subdomain used for staging API

If production infra only uses one of these hostnames, the extra entry is harmless; remove it in review if you standardise on a single staging URL.

Made with [Cursor](https://cursor.com)