### PR TITLE
Chore: Hyphenate staging URL's for readability purposes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
           - component: frontend
             dockerfile: production.dockerfile
             args: |
-              "API_URL=${{ github.ref_name == 'dev' && 'https://circlesapi.devsoc.app' || 'https://circlesstagingapi.devsoc.app' }}"
+              "API_URL=${{ github.ref_name == 'dev' && 'https://circlesapi.devsoc.app' || 'https://circles-staging.devsoc.app' }}"
           - component: backend
             dockerfile: production.dockerfile
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,7 +24,7 @@ jobs:
           - component: frontend
             dockerfile: production.dockerfile
             args: |
-              "API_URL=${{ github.ref_name == 'dev' && 'https://circlesapi.devsoc.app' || 'https://circles-staging.devsoc.app' }}"
+              "API_URL=${{ github.ref_name == 'dev' && 'https://circlesapi.devsoc.app' || 'https://circles-staging-api.devsoc.app' }}"
           - component: backend
             dockerfile: production.dockerfile
     steps:

--- a/backend/server/server.py
+++ b/backend/server/server.py
@@ -35,7 +35,7 @@ origins = [
     "http://frontend:3000",
     "http://frontend:3001",
     "https://circles.devsoc.app",
-    "https://circlesstaging.devsoc.app",
+    "https://circles-staging.devsoc.app",
     "https://unilectives.devsoc.app",
     "https://unilectives.staging.devsoc.app",
 ]


### PR DESCRIPTION
As per request of the platforms directors, I have hyphenated circlesstagingapi.devsoc.app and circlesstaging.devsoc.app to circles-staging-api.devsoc.app and circles-staging.devsoc.app for easier readability.