### PR TITLE
feat(backend): add rate limiting to guest_login route

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ click==8.1.7
 cryptography==46.0.6
 dnspython==2.6.1
 fastapi==0.135.2
+fastapi-limiter==0.1.6
 fuzzywuzzy==0.18.0
 h11==0.16.0
 hiredis==3.0.0

--- a/backend/server/db/redis/limiter_conn.py
+++ b/backend/server/db/redis/limiter_conn.py
@@ -1,0 +1,18 @@
+import os
+import redis.asyncio as aioredis
+
+# fastapi-limiter needs an async redis client, separate from the sync `sdb`
+# used for sessions. 
+# We point it at the same Redis server but a different logical db (db=1) 
+# so limiter keys never collide with session keys.
+def make_limiter_redis() -> "aioredis.Redis":
+    return aioredis.Redis(
+        host=os.environ["SESSIONSDB_SERVICE_HOSTNAME"],
+        port=6379,
+        db=1,                       # separate logical db from sessions (db=0)
+        protocol=3,
+        encoding="utf-8",
+        decode_responses=True,
+        username=os.environ["SESSIONSDB_USERNAME"],
+        password=os.environ["SESSIONSDB_PASSWORD"],
+    )

--- a/backend/server/routers/dev.py
+++ b/backend/server/routers/dev.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Response
+from fastapi import APIRouter, Response, Depends
+from fastapi_limiter.depends import RateLimiter
 
 from server.routers.auth import REFRESH_TOKEN_COOKIE, IdentityPayload, insert_new_guest_user
 from server.routers.utility.sessions.interface import setup_new_guest_session
@@ -10,7 +11,9 @@ router = APIRouter(
     tags=["dev"],
 )
 
-@router.post('/guest_login')
+@router.post('/guest_login', 
+             dependencies=[Depends(RateLimiter(times=3, seconds=60))],
+            )
 def create_guest_session(res: Response) -> IdentityPayload:
     # create new login session for user in db, generating new tokens
     uid = insert_new_guest_user()

--- a/backend/server/server.py
+++ b/backend/server/server.py
@@ -6,14 +6,20 @@ import os
 from contextlib import asynccontextmanager
 from data.config import LIVE_YEAR
 from fastapi import FastAPI
+from fastapi_limiter import FastAPILimiter
 from fastapi.middleware.cors import CORSMiddleware
+from server.db.redis.limiter_conn import make_limiter_redis
 from server.routers import auth, courses, followups, planner, programs, specialisations, user
 
 @asynccontextmanager
 async def on_setup_and_shutdown(_app: FastAPI):
     # TODO-OLLI(pm): actually use these
     print("\n\nstartup\n\n")
+    limiter_redis = make_limiter_redis()
+    await FastAPILimiter.init(limiter_redis) # connect limiter to redis
     yield
+    await FastAPILimiter.close() # clean shutdown
+    await limiter_redis.aclose()
     print("\n\nshutdown\n\n")
 
 app = FastAPI(lifespan=on_setup_and_shutdown)


### PR DESCRIPTION
## Summary

Added rate limiting to the backend using `fastapi-limiter` to `guest_login` route.

## Changes

- Installed `fastapi-limiter` and set up an async Redis client pointing to a separate logical db (`db=1`) so limiter keys don't collide with session keys (`db=0`)
- Initialised the limiter in the app's lifespan hook so it starts up and tears down with the server
- Applied rate limiting to the `guest_login` route -> Currently a rate of 3 times/60s 