### PR TITLE
chore(backend): add type casts to guest login rate limit test

### DIFF
--- a/backend/server/tests/user/test_guest_login_rate_limit.py
+++ b/backend/server/tests/user/test_guest_login_rate_limit.py
@@ -1,5 +1,6 @@
 import os
 import time
+from typing import cast
 
 import redis
 import requests
@@ -27,10 +28,10 @@ def fast_forward_limiter_window():
     """
     limiter_db = redis.Redis(**limiter_redis_kwargs())
     try:
-        keys = limiter_db.keys("*")
+        keys = cast(list, limiter_db.keys("*"))
         assert keys, "expected limiter counters to exist before the window expires"
         for key in keys:
-            assert limiter_db.pttl(key) > 0, "limiter counter should carry a TTL"
+            assert cast(int, limiter_db.pttl(key)) > 0, "limiter counter should carry a TTL"
             limiter_db.pexpire(key, 1)  # expire ~immediately
     finally:
         limiter_db.close()


### PR DESCRIPTION
# Brief

Cleaned up type checker complaints in the guest login rate limit test as Redis client returned loose types.

# Changes

- Added the from typing import cast import.
- Wrapped limiter_db.keys("*") in cast(list, ...) so it knows we're dealing with a list when we assert and loop over the keys.
- Wrapped limiter_db.pttl(key) in cast(int, ...) so the > 0 check stops throwing a warning, as pttl comes back as a vague union type otherwise.